### PR TITLE
Implement bulk IP add route

### DIFF
--- a/blacklist_monitor/templates/ips.html
+++ b/blacklist_monitor/templates/ips.html
@@ -5,6 +5,12 @@
     <input type="text" name="ip" placeholder="IP or CIDR range" required>
     <input type="submit" value="Add">
 </form>
+<h2>Bulk Add</h2>
+<form method="post" action="{{ url_for('bulk_ips') }}">
+    <textarea name="ips_bulk" rows="4" cols="40" placeholder="one IP or CIDR per line"></textarea>
+    <br>
+    <input type="submit" value="Add List">
+</form>
 <table>
     <tr><th>IP</th><th>Action</th></tr>
     {% for ip in ips %}


### PR DESCRIPTION
## Summary
- add `/ips/bulk` POST route to load many IPs at once
- support multiline IP or CIDR input from web
- extend IPs management page with new bulk add form

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6864cb5321b08321a96f6ad808612e5f