### PR TITLE
Improve blacklist monitor UI and scheduling

### DIFF
--- a/blacklist_monitor/static/style.css
+++ b/blacklist_monitor/static/style.css
@@ -1,6 +1,7 @@
 body {
     font-family: Arial, sans-serif;
     margin: 0;
+    font-size: 16px;
 }
 
 .container {
@@ -42,4 +43,15 @@ th, td {
     border: 1px solid #ccc;
     padding: 0.5em;
     text-align: left;
+}
+
+button, input[type="submit"] {
+    margin: 0.2em;
+    padding: 0.4em 0.8em;
+}
+
+.group-header {
+    cursor: pointer;
+    background-color: #e0e0e0;
+    padding: 0.3em;
 }

--- a/blacklist_monitor/templates/base.html
+++ b/blacklist_monitor/templates/base.html
@@ -14,6 +14,7 @@
             <li><a href="{{ url_for('manage_dnsbls') }}">DNSBLs</a></li>
             <li><a href="{{ url_for('manage_groups') }}">Groups</a></li>
             <li><a href="{{ url_for('schedule_view') }}">Schedule</a></li>
+            <li><a href="{{ url_for('telegram_settings') }}">Telegram</a></li>
         </ul>
     </div>
     <div class="content">

--- a/blacklist_monitor/templates/groups.html
+++ b/blacklist_monitor/templates/groups.html
@@ -6,9 +6,16 @@
     <input type="submit" value="Add">
 </form>
 <table>
-    <tr><th>Group</th></tr>
+    <tr><th>Group</th><th>Action</th></tr>
     {% for g in groups %}
-    <tr><td>{{ g[1] }}</td></tr>
+    <tr>
+        <td>{{ g[1] }}</td>
+        <td>
+            <form method="post" action="{{ url_for('delete_group', group_id=g[0]) }}">
+                <button type="submit">Delete</button>
+            </form>
+        </td>
+    </tr>
     {% endfor %}
 </table>
 {% endblock %}

--- a/blacklist_monitor/templates/index.html
+++ b/blacklist_monitor/templates/index.html
@@ -2,22 +2,49 @@
 {% block content %}
 <h1>Monitored IPs</h1>
 <p>Total IPs: {{ ip_count }}</p>
-<p>Next scheduled check: {{ next_run }}</p>
-<table>
-    <tr><th>IP</th><th>Last Checked</th><th>Status</th><th>Action</th></tr>
-    {% for ip in ips %}
-    <tr>
-        <td>{{ ip[1] }}</td>
-        <td>{{ ip[2] or 'never' }}</td>
-        <td>
-            {% if ip[3] == 1 %}listed{% elif ip[3] == 0 %}clean{% else %}-{% endif %}
-        </td>
-        <td>
-            <form method="post" action="{{ url_for('manual_check', ip_id=ip[0]) }}">
-                <button type="submit">Check</button>
-            </form>
-        </td>
-    </tr>
+<p>Next scheduled check: {{ next_run and next_run.strftime('%H:%M') }}</p>
+<form method="post" action="{{ url_for('check_selected') }}">
+    <button type="submit">Check Selected</button>
+    {% for g in groups %}
+        <h3 onclick="toggle('g{{ g[0] }}')" class="group-header">{{ g[1] }}</h3>
+        <div id="g{{ g[0] }}">
+        <table>
+            <tr><th></th><th>IP</th><th>Last Checked</th><th>Status</th><th>DNSBL</th></tr>
+            {% for ip in ips %}
+                {% if ip[3] == g[0] %}
+                <tr>
+                    <td><input type="checkbox" name="ip_id" value="{{ ip[0] }}"></td>
+                    <td>{{ ip[1] }}</td>
+                    <td>{{ ip[2] or 'never' }}</td>
+                    <td>{% if ip[4] == 1 %}listed{% elif ip[4] == 0 %}clean{% else %}-{% endif %}</td>
+                    <td>{{ dnsbl_map[ip[0]]|join(', ') }}</td>
+                </tr>
+                {% endif %}
+            {% endfor %}
+        </table>
+        </div>
     {% endfor %}
-</table>
+    {% set ungroup = [] %}
+    {% for ip in ips %}{% if not ip[3] %}{% set _ = ungroup.append(ip) %}{% endif %}{% endfor %}
+    {% if ungroup %}
+        <h3 onclick="toggle('g0')" class="group-header">Ungrouped</h3>
+        <div id="g0">
+        <table>
+            <tr><th></th><th>IP</th><th>Last Checked</th><th>Status</th><th>DNSBL</th></tr>
+            {% for ip in ungroup %}
+            <tr>
+                <td><input type="checkbox" name="ip_id" value="{{ ip[0] }}"></td>
+                <td>{{ ip[1] }}</td>
+                <td>{{ ip[2] or 'never' }}</td>
+                <td>{% if ip[4] == 1 %}listed{% elif ip[4] == 0 %}clean{% else %}-{% endif %}</td>
+                <td>{{ dnsbl_map[ip[0]]|join(', ') }}</td>
+            </tr>
+            {% endfor %}
+        </table>
+        </div>
+    {% endif %}
+</form>
+<script>
+function toggle(id){var e=document.getElementById(id);if(e){e.style.display=e.style.display==='none'?'':'none';}}
+</script>
 {% endblock %}

--- a/blacklist_monitor/templates/ips.html
+++ b/blacklist_monitor/templates/ips.html
@@ -30,24 +30,50 @@
         {% endfor %}
     </select>
     <input type="submit" value="Set Group">
-    <table>
-        <tr><th></th><th>IP</th><th>Group</th><th>Action</th></tr>
-        {% for ip in ips %}
-        <tr>
-            <td><input type="checkbox" name="ip_id" value="{{ ip[0] }}"></td>
-            <td>{{ ip[1] }}</td>
-            <td>
-                {% for g in groups %}
-                    {% if g[0] == ip[2] %}{{ g[1] }}{% endif %}
-                {% endfor %}
-            </td>
-            <td>
-                <form method="post" action="{{ url_for('delete_ip', ip_id=ip[0]) }}">
-                    <button type="submit">Delete</button>
-                </form>
-            </td>
-        </tr>
-        {% endfor %}
-    </table>
+    {% for g in groups %}
+        <h3 onclick="toggle('grp{{ g[0] }}')" class="group-header">{{ g[1] }}</h3>
+        <div id="grp{{ g[0] }}">
+        <table>
+            <tr><th></th><th>IP</th><th>Action</th></tr>
+            {% for ip in ips %}
+                {% if ip[2] == g[0] %}
+                <tr>
+                    <td><input type="checkbox" name="ip_id" value="{{ ip[0] }}"></td>
+                    <td>{{ ip[1] }}</td>
+                    <td>
+                        <form method="post" action="{{ url_for('delete_ip', ip_id=ip[0]) }}">
+                            <button type="submit">Delete</button>
+                        </form>
+                    </td>
+                </tr>
+                {% endif %}
+            {% endfor %}
+        </table>
+        </div>
+    {% endfor %}
+    {% set ungroup = [] %}
+    {% for ip in ips %}{% if not ip[2] %}{% set _ = ungroup.append(ip) %}{% endif %}{% endfor %}
+    {% if ungroup %}
+        <h3 onclick="toggle('grp0')" class="group-header">Ungrouped</h3>
+        <div id="grp0">
+        <table>
+            <tr><th></th><th>IP</th><th>Action</th></tr>
+            {% for ip in ungroup %}
+            <tr>
+                <td><input type="checkbox" name="ip_id" value="{{ ip[0] }}"></td>
+                <td>{{ ip[1] }}</td>
+                <td>
+                    <form method="post" action="{{ url_for('delete_ip', ip_id=ip[0]) }}">
+                        <button type="submit">Delete</button>
+                    </form>
+                </td>
+            </tr>
+            {% endfor %}
+        </table>
+        </div>
+    {% endif %}
 </form>
+<script>
+function toggle(id){var e=document.getElementById(id);if(e){e.style.display=e.style.display==='none'?'':'none';}}
+</script>
 {% endblock %}

--- a/blacklist_monitor/templates/schedule.html
+++ b/blacklist_monitor/templates/schedule.html
@@ -2,9 +2,11 @@
 {% block content %}
 <h1>Schedule</h1>
 <form method="post">
-    <label>Check interval (hours):</label>
-    <input type="number" step="0.1" name="hours" value="{{ hours }}">
+    <label>Hours:</label>
+    <input type="number" name="hours" value="{{ hours }}" min="0">
+    <label>Minutes:</label>
+    <input type="number" name="minutes" value="{{ minutes }}" min="0" max="59">
     <input type="submit" value="Update">
 </form>
-<p>Next run: {{ next_run }}</p>
+<p>Next run: {{ next_run and next_run.strftime('%H:%M') }}</p>
 {% endblock %}

--- a/blacklist_monitor/templates/telegram.html
+++ b/blacklist_monitor/templates/telegram.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Telegram Settings</h1>
+<form method="post">
+    <label>Bot Token:</label>
+    <input type="text" name="token" value="{{ token }}">
+    <br>
+    <label>Chat ID:</label>
+    <input type="text" name="chat_id" value="{{ chat_id }}">
+    <br>
+    <button type="submit" name="action" value="Save">Save</button>
+    <button type="submit" name="action" value="Test">Test</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add settings table and telegram management page
- support scheduled checks in minutes and show next run in HH:MM
- consolidate dashboard checks with group expansion and DNSBL details
- allow group deletion and collapsible IP listing
- add Telegram side pane, bigger fonts, and button spacing

## Testing
- `python -m py_compile blacklist_monitor/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6864e03cf19483218a5c6a4f9ad9888e