### PR TITLE
Support multi-delete for IPs and DNSBLs

### DIFF
--- a/blacklist_monitor/app.py
+++ b/blacklist_monitor/app.py
@@ -159,6 +159,20 @@ def delete_ip(ip_id):
     return redirect(url_for('manage_ips'))
 
 
+@app.route('/ips/delete_selected', methods=['POST'])
+def delete_selected_ips():
+    ids = request.form.getlist('ip_id')
+    with sqlite3.connect(DB_PATH) as conn:
+        c = conn.cursor()
+        for ip_id in ids:
+            try:
+                c.execute('DELETE FROM ip_addresses WHERE id=?', (ip_id,))
+            except sqlite3.Error:
+                pass
+        conn.commit()
+    return redirect(url_for('manage_ips'))
+
+
 @app.route('/dnsbls', methods=['GET', 'POST'])
 def manage_dnsbls():
     with sqlite3.connect(DB_PATH) as conn:
@@ -192,6 +206,20 @@ def delete_dnsbl(dnsbl_id):
     with sqlite3.connect(DB_PATH) as conn:
         c = conn.cursor()
         c.execute('DELETE FROM dnsbls WHERE id=?', (dnsbl_id,))
+        conn.commit()
+    return redirect(url_for('manage_dnsbls'))
+
+
+@app.route('/dnsbls/delete_selected', methods=['POST'])
+def delete_selected_dnsbls():
+    ids = request.form.getlist('dnsbl_id')
+    with sqlite3.connect(DB_PATH) as conn:
+        c = conn.cursor()
+        for dnsbl_id in ids:
+            try:
+                c.execute('DELETE FROM dnsbls WHERE id=?', (dnsbl_id,))
+            except sqlite3.Error:
+                pass
         conn.commit()
     return redirect(url_for('manage_dnsbls'))
 

--- a/blacklist_monitor/templates/dnsbls.html
+++ b/blacklist_monitor/templates/dnsbls.html
@@ -11,17 +11,16 @@
     <br>
     <input type="submit" value="Add List">
 </form>
-<table>
-    <tr><th>DNSBL</th><th>Action</th></tr>
-    {% for dnsbl in dnsbls %}
-    <tr>
-        <td>{{ dnsbl[1] }}</td>
-        <td>
-            <form method="post" action="{{ url_for('delete_dnsbl', dnsbl_id=dnsbl[0]) }}">
-                <button type="submit">Delete</button>
-            </form>
-        </td>
-    </tr>
-    {% endfor %}
-</table>
+<form method="post" action="{{ url_for('delete_selected_dnsbls') }}">
+    <button type="submit">Delete Selected</button>
+    <table>
+        <tr><th></th><th>DNSBL</th></tr>
+        {% for dnsbl in dnsbls %}
+        <tr>
+            <td><input type="checkbox" name="dnsbl_id" value="{{ dnsbl[0] }}"></td>
+            <td>{{ dnsbl[1] }}</td>
+        </tr>
+        {% endfor %}
+    </table>
+</form>
 {% endblock %}

--- a/blacklist_monitor/templates/ips.html
+++ b/blacklist_monitor/templates/ips.html
@@ -30,21 +30,17 @@
         {% endfor %}
     </select>
     <input type="submit" value="Set Group">
+    <button type="submit" formaction="{{ url_for('delete_selected_ips') }}">Delete Selected</button>
     {% for g in groups %}
         <h3 onclick="toggle('grp{{ g[0] }}')" class="group-header">{{ g[1] }}</h3>
         <div id="grp{{ g[0] }}">
         <table>
-            <tr><th></th><th>IP</th><th>Action</th></tr>
+            <tr><th></th><th>IP</th></tr>
             {% for ip in ips %}
                 {% if ip[2] == g[0] %}
                 <tr>
                     <td><input type="checkbox" name="ip_id" value="{{ ip[0] }}"></td>
                     <td>{{ ip[1] }}</td>
-                    <td>
-                        <form method="post" action="{{ url_for('delete_ip', ip_id=ip[0]) }}">
-                            <button type="submit">Delete</button>
-                        </form>
-                    </td>
                 </tr>
                 {% endif %}
             {% endfor %}
@@ -57,16 +53,11 @@
         <h3 onclick="toggle('grp0')" class="group-header">Ungrouped</h3>
         <div id="grp0">
         <table>
-            <tr><th></th><th>IP</th><th>Action</th></tr>
+            <tr><th></th><th>IP</th></tr>
             {% for ip in ungroup %}
             <tr>
                 <td><input type="checkbox" name="ip_id" value="{{ ip[0] }}"></td>
                 <td>{{ ip[1] }}</td>
-                <td>
-                    <form method="post" action="{{ url_for('delete_ip', ip_id=ip[0]) }}">
-                        <button type="submit">Delete</button>
-                    </form>
-                </td>
             </tr>
             {% endfor %}
         </table>


### PR DESCRIPTION
## Summary
- allow bulk delete of IPs and DNSBLs
- update UI with single delete buttons and row checkboxes

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6864ee71cd248321bdd68fd8c097cf08