### PR TITLE
Add select all checkbox and style telegram inputs

### DIFF
--- a/blacklist_monitor/static/style.css
+++ b/blacklist_monitor/static/style.css
@@ -55,3 +55,11 @@ button, input[type="submit"] {
     background-color: #e0e0e0;
     padding: 0.3em;
 }
+
+.telegram-input {
+    padding: 0.4em;
+    margin: 0.2em 0;
+    width: 300px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}

--- a/blacklist_monitor/templates/index.html
+++ b/blacklist_monitor/templates/index.html
@@ -9,7 +9,7 @@
         <h3 onclick="toggle('g{{ g[0] }}')" class="group-header">{{ g[1] }}</h3>
         <div id="g{{ g[0] }}">
         <table>
-            <tr><th></th><th>IP</th><th>Last Checked</th><th>Status</th><th>DNSBL</th></tr>
+            <tr><th><input type="checkbox" onclick="toggleAll(this)"></th><th>IP</th><th>Last Checked</th><th>Status</th><th>DNSBL</th></tr>
             {% for ip in ips %}
                 {% if ip[3] == g[0] %}
                 <tr>
@@ -30,7 +30,7 @@
         <h3 onclick="toggle('g0')" class="group-header">Ungrouped</h3>
         <div id="g0">
         <table>
-            <tr><th></th><th>IP</th><th>Last Checked</th><th>Status</th><th>DNSBL</th></tr>
+            <tr><th><input type="checkbox" onclick="toggleAll(this)"></th><th>IP</th><th>Last Checked</th><th>Status</th><th>DNSBL</th></tr>
             {% for ip in ungroup %}
             <tr>
                 <td><input type="checkbox" name="ip_id" value="{{ ip[0] }}"></td>
@@ -46,5 +46,6 @@
 </form>
 <script>
 function toggle(id){var e=document.getElementById(id);if(e){e.style.display=e.style.display==='none'?'':'none';}}
+function toggleAll(src){var tbl=src.closest('table');if(!tbl)return;var boxes=tbl.querySelectorAll('input[type="checkbox"][name="ip_id"]');boxes.forEach(function(cb){cb.checked=src.checked;});}
 </script>
 {% endblock %}

--- a/blacklist_monitor/templates/telegram.html
+++ b/blacklist_monitor/templates/telegram.html
@@ -3,10 +3,10 @@
 <h1>Telegram Settings</h1>
 <form method="post">
     <label>Bot Token:</label>
-    <input type="text" name="token" value="{{ token }}">
+    <input type="text" name="token" value="{{ token }}" class="telegram-input">
     <br>
     <label>Chat ID:</label>
-    <input type="text" name="chat_id" value="{{ chat_id }}">
+    <input type="text" name="chat_id" value="{{ chat_id }}" class="telegram-input">
     <br>
     <button type="submit" name="action" value="Save">Save</button>
     <button type="submit" name="action" value="Test">Test</button>


### PR DESCRIPTION
## Summary
- add a select-all checkbox to dashboard tables
- style Telegram bot token and chat ID inputs

## Testing
- `python3 -m py_compile blacklist_monitor/app.py`


------
https://chatgpt.com/codex/tasks/task_e_6864fd6a688c8321a3a36a2a00ece541