### PR TITLE
Fix DB locks and add select-all controls

### DIFF
--- a/blacklist_monitor/README.md
+++ b/blacklist_monitor/README.md
@@ -20,6 +20,7 @@ Features:
    ```
 2. Set the environment variables `TELEGRAM_TOKEN` and `TELEGRAM_CHAT_ID` for Telegram alerts.
    Optionally set `CHECK_INTERVAL_HOURS` to change the default check interval.
+   `DB_TIMEOUT` can be used to adjust the SQLite write timeout (default is 30 seconds).
 3. Run the app:
    ```bash
    python app.py

--- a/blacklist_monitor/templates/dnsbls.html
+++ b/blacklist_monitor/templates/dnsbls.html
@@ -14,7 +14,7 @@
 <form method="post" action="{{ url_for('delete_selected_dnsbls') }}">
     <button type="submit">Delete Selected</button>
     <table>
-        <tr><th></th><th>DNSBL</th></tr>
+        <tr><th><input type="checkbox" onclick="toggleAll(this)"></th><th>DNSBL</th></tr>
         {% for dnsbl in dnsbls %}
         <tr>
             <td><input type="checkbox" name="dnsbl_id" value="{{ dnsbl[0] }}"></td>
@@ -23,4 +23,7 @@
         {% endfor %}
     </table>
 </form>
+<script>
+function toggleAll(src){var tbl=src.closest('table');if(!tbl)return;var boxes=tbl.querySelectorAll('input[type="checkbox"][name="dnsbl_id"]');boxes.forEach(function(cb){cb.checked=src.checked;});}
+</script>
 {% endblock %}

--- a/blacklist_monitor/templates/groups.html
+++ b/blacklist_monitor/templates/groups.html
@@ -5,17 +5,19 @@
     <input type="text" name="group" placeholder="Group name" required>
     <input type="submit" value="Add">
 </form>
-<table>
-    <tr><th>Group</th><th>Action</th></tr>
-    {% for g in groups %}
-    <tr>
-        <td>{{ g[1] }}</td>
-        <td>
-            <form method="post" action="{{ url_for('delete_group', group_id=g[0]) }}">
-                <button type="submit">Delete</button>
-            </form>
-        </td>
-    </tr>
-    {% endfor %}
-</table>
+<form method="post" action="{{ url_for('delete_selected_groups') }}">
+    <button type="submit">Delete Selected</button>
+    <table>
+        <tr><th><input type="checkbox" onclick="toggleAll(this)"></th><th>Group</th></tr>
+        {% for g in groups %}
+        <tr>
+            <td><input type="checkbox" name="group_id" value="{{ g[0] }}"></td>
+            <td>{{ g[1] }}</td>
+        </tr>
+        {% endfor %}
+    </table>
+</form>
+<script>
+function toggleAll(src){var tbl=src.closest('table');if(!tbl)return;var boxes=tbl.querySelectorAll('input[type="checkbox"][name="group_id"]');boxes.forEach(function(cb){cb.checked=src.checked;});}
+</script>
 {% endblock %}

--- a/blacklist_monitor/templates/ips.html
+++ b/blacklist_monitor/templates/ips.html
@@ -35,7 +35,7 @@
         <h3 onclick="toggle('grp{{ g[0] }}')" class="group-header">{{ g[1] }}</h3>
         <div id="grp{{ g[0] }}">
         <table>
-            <tr><th></th><th>IP</th></tr>
+            <tr><th><input type="checkbox" onclick="toggleAll(this)"></th><th>IP</th></tr>
             {% for ip in ips %}
                 {% if ip[2] == g[0] %}
                 <tr>
@@ -53,7 +53,7 @@
         <h3 onclick="toggle('grp0')" class="group-header">Ungrouped</h3>
         <div id="grp0">
         <table>
-            <tr><th></th><th>IP</th></tr>
+            <tr><th><input type="checkbox" onclick="toggleAll(this)"></th><th>IP</th></tr>
             {% for ip in ungroup %}
             <tr>
                 <td><input type="checkbox" name="ip_id" value="{{ ip[0] }}"></td>
@@ -66,5 +66,6 @@
 </form>
 <script>
 function toggle(id){var e=document.getElementById(id);if(e){e.style.display=e.style.display==='none'?'':'none';}}
+function toggleAll(src){var tbl=src.closest('table');if(!tbl)return;var boxes=tbl.querySelectorAll('input[type="checkbox"][name="ip_id"]');boxes.forEach(function(cb){cb.checked=src.checked;});}
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- prevent database lock errors by using a connection helper with a longer timeout
- document new `DB_TIMEOUT` environment variable
- add Select All checkboxes to IPs, DNSBLs and Groups pages
- enable deleting multiple groups at once

## Testing
- `python -m py_compile blacklist_monitor/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6865f80409a883219747c91d4dbe02f6