### PR TITLE
Implement blacklist check exclusions and Telegram customization

### DIFF
--- a/blacklist_monitor/templates/index.html
+++ b/blacklist_monitor/templates/index.html
@@ -5,19 +5,22 @@
 <p>Next scheduled check: {{ next_run and next_run.strftime('%H:%M') }}</p>
 <form method="post" action="{{ url_for('check_selected') }}">
     <button type="submit">Check Selected</button>
+    <button type="submit" formaction="{{ url_for('exclude_selected') }}">Exclude Selected</button>
+    <button type="submit" formaction="{{ url_for('include_selected') }}">Include Selected</button>
     {% for g in groups %}
         <h3 onclick="toggle('g{{ g[0] }}')" class="group-header">{{ g[1] }}</h3>
         <div id="g{{ g[0] }}">
         <table>
-            <tr><th><input type="checkbox" onclick="toggleAll(this)"></th><th>IP</th><th>Last Checked</th><th>Status</th><th>DNSBL</th></tr>
+            <tr><th><input type="checkbox" onclick="toggleAll(this)"></th><th>IP</th><th>Last Checked</th><th>Status</th><th>DNSBL</th><th>Excluded</th></tr>
             {% for ip in ips %}
                 {% if ip[3] == g[0] %}
                 <tr>
                     <td><input type="checkbox" name="ip_id" value="{{ ip[0] }}"></td>
                     <td>{{ ip[1] }}</td>
                     <td>{{ ip[2] or 'never' }}</td>
-                    <td>{% if ip[4] == 1 %}listed{% elif ip[4] == 0 %}clean{% else %}-{% endif %}</td>
+                    <td>{% if ip[5] == 1 %}listed{% elif ip[5] == 0 %}clean{% else %}-{% endif %}</td>
                     <td>{{ dnsbl_map[ip[0]]|join(', ') }}</td>
+                    <td>{{ 'yes' if ip[4] else 'no' }}</td>
                 </tr>
                 {% endif %}
             {% endfor %}
@@ -30,14 +33,15 @@
         <h3 onclick="toggle('g0')" class="group-header">Ungrouped</h3>
         <div id="g0">
         <table>
-            <tr><th><input type="checkbox" onclick="toggleAll(this)"></th><th>IP</th><th>Last Checked</th><th>Status</th><th>DNSBL</th></tr>
+            <tr><th><input type="checkbox" onclick="toggleAll(this)"></th><th>IP</th><th>Last Checked</th><th>Status</th><th>DNSBL</th><th>Excluded</th></tr>
             {% for ip in ungroup %}
             <tr>
                 <td><input type="checkbox" name="ip_id" value="{{ ip[0] }}"></td>
                 <td>{{ ip[1] }}</td>
                 <td>{{ ip[2] or 'never' }}</td>
-                <td>{% if ip[4] == 1 %}listed{% elif ip[4] == 0 %}clean{% else %}-{% endif %}</td>
+                <td>{% if ip[5] == 1 %}listed{% elif ip[5] == 0 %}clean{% else %}-{% endif %}</td>
                 <td>{{ dnsbl_map[ip[0]]|join(', ') }}</td>
+                <td>{{ 'yes' if ip[4] else 'no' }}</td>
             </tr>
             {% endfor %}
         </table>
@@ -45,7 +49,8 @@
     {% endif %}
 </form>
 <script>
-function toggle(id){var e=document.getElementById(id);if(e){e.style.display=e.style.display==='none'?'':'none';}}
+function toggle(id){var e=document.getElementById(id);if(!e)return;var s=e.style.display==='none'?'':'none';e.style.display=s;localStorage.setItem('collapse_'+id,s);}
+window.addEventListener('load',function(){document.querySelectorAll('div[id^="g"]').forEach(function(el){var s=localStorage.getItem('collapse_'+el.id);if(s!==null){el.style.display=s;}});});
 function toggleAll(src){var tbl=src.closest('table');if(!tbl)return;var boxes=tbl.querySelectorAll('input[type="checkbox"][name="ip_id"]');boxes.forEach(function(cb){cb.checked=src.checked;});}
 </script>
 {% endblock %}

--- a/blacklist_monitor/templates/telegram.html
+++ b/blacklist_monitor/templates/telegram.html
@@ -1,12 +1,19 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Telegram Settings</h1>
+<p>Saved Token: {{ token_display }}</p>
+<p>Saved Chat ID: {{ chat_id_display }}</p>
 <form method="post">
     <label>Bot Token:</label>
-    <input type="text" name="token" value="{{ token }}" class="telegram-input">
+    <input type="text" name="token" class="telegram-input">
     <br>
     <label>Chat ID:</label>
-    <input type="text" name="chat_id" value="{{ chat_id }}" class="telegram-input">
+    <input type="text" name="chat_id" class="telegram-input">
+    <br>
+    <label>Alert Message:</label>
+    <input type="text" name="alert_message" value="{{ message }}" class="telegram-input">
+    <br>
+    <label><input type="checkbox" name="resend_periodic" {% if resend_periodic %}checked{% endif %}> Resend periodic alerts</label>
     <br>
     <button type="submit" name="action" value="Save">Save</button>
     <button type="submit" name="action" value="Test">Test</button>


### PR DESCRIPTION
## Summary
- allow IPs to be excluded from automatic checks
- remember Dashboard group collapse state
- enhance Telegram settings with message template and resend toggle

## Testing
- `python -m py_compile blacklist_monitor/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6866116249ac832187d464fa07d13893