### PR TITLE
Fix scheduler logic and UI improvements

### DIFF
--- a/blacklist_monitor/templates/groups.html
+++ b/blacklist_monitor/templates/groups.html
@@ -2,7 +2,7 @@
 {% block content %}
 <h1>Groups</h1>
 <form method="post">
-    <input type="text" name="group" placeholder="Group name" required>
+    <input type="text" name="group" placeholder="Group name" required class="telegram-input">
     <input type="submit" value="Add">
 </form>
 <table>

--- a/blacklist_monitor/templates/ips.html
+++ b/blacklist_monitor/templates/ips.html
@@ -25,6 +25,7 @@
 </form>
 <form method="post" id="group-form" action="{{ url_for('set_group') }}">
     <select name="group_id">
+        <option value="">Ungroup</option>
         {% for g in groups %}
         <option value="{{ g[0] }}">{{ g[1] }}</option>
         {% endfor %}
@@ -65,7 +66,8 @@
     {% endif %}
 </form>
 <script>
-function toggle(id){var e=document.getElementById(id);if(e){e.style.display=e.style.display==='none'?'':'none';}}
+function toggle(id){var e=document.getElementById(id);if(!e)return;var s=e.style.display==='none'?'':'none';e.style.display=s;localStorage.setItem('collapse_'+id,s);}
+window.addEventListener('load',function(){document.querySelectorAll('div[id^="grp"]').forEach(function(el){var s=localStorage.getItem('collapse_'+el.id);if(s!==null){el.style.display=s;}});});
 function toggleAll(src){var tbl=src.closest('table');if(!tbl)return;var boxes=tbl.querySelectorAll('input[type="checkbox"][name="ip_id"]');boxes.forEach(function(cb){cb.checked=src.checked;});}
 </script>
 {% endblock %}

--- a/blacklist_monitor/templates/schedule.html
+++ b/blacklist_monitor/templates/schedule.html
@@ -3,9 +3,9 @@
 <h1>Schedule</h1>
 <form method="post">
     <label>Hours:</label>
-    <input type="number" name="hours" value="0" placeholder="{{ hours }}" min="0">
+    <input type="number" name="hours" value="0" placeholder="{{ hours }}" min="0" class="telegram-input">
     <label>Minutes:</label>
-    <input type="number" name="minutes" value="0" placeholder="{{ minutes }}" min="0" max="59">
+    <input type="number" name="minutes" value="0" placeholder="{{ minutes }}" min="0" max="59" class="telegram-input">
     <input type="submit" value="Update">
 </form>
 <p>Next run: {{ next_run and next_run.strftime('%H:%M') }}</p>

--- a/blacklist_monitor/templates/telegram.html
+++ b/blacklist_monitor/templates/telegram.html
@@ -31,8 +31,8 @@
     <input type="text" name="alert_message" value="{{ message }}" class="telegram-input">
     <br>
     <label>Resend period:</label>
-    <input type="number" name="resend_hours" value="0" placeholder="{{ resend_hours }}" min="0"> h
-    <input type="number" name="resend_minutes" value="0" placeholder="{{ resend_minutes }}" min="0" max="59"> m (0 = none)
+    <input type="number" name="resend_hours" value="0" placeholder="{{ resend_hours }}" min="0" class="telegram-input"> h
+    <input type="number" name="resend_minutes" value="0" placeholder="{{ resend_minutes }}" min="0" max="59" class="telegram-input"> m (0 = none)
     <br>
     <button type="submit">Save</button>
     <button type="submit" name="action" value="Test">Test</button>


### PR DESCRIPTION
## Summary
- skip blacklist checks for excluded IPs
- preserve collapsed IP groups in the UI
- allow ungrouping IPs and polish inputs
- default schedule disabled when no interval is set
- send Telegram test messages to all active chats

## Testing
- `python -m py_compile app.py`
- `python app.py >/tmp/app.log 2>&1 & sleep 5; kill $!; cat /tmp/app.log | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_686645582cf48321b34c6be0da01d868