### PR TITLE
Implement UI updates and server time display

### DIFF
--- a/blacklist_monitor/app.py
+++ b/blacklist_monitor/app.py
@@ -320,7 +320,7 @@ def check_ip(ip_id):
             return
         ip = row[0]
         dnsbls = c.execute('SELECT id, domain FROM dnsbls').fetchall()
-        timestamp = datetime.datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')
+        timestamp = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
         for dnsbl_id, dnsbl in dnsbls:
             query = '.'.join(reversed(ip.split('.'))) + '.' + dnsbl
             listed = 0
@@ -338,7 +338,7 @@ def check_ip(ip_id):
                 else:
                     if prev:
                         prev_time = datetime.datetime.strptime(prev[1], '%Y-%m-%d %H:%M:%S')
-                        if datetime.datetime.utcnow() - prev_time < datetime.timedelta(minutes=period):
+                        if datetime.datetime.now() - prev_time < datetime.timedelta(minutes=period):
                             send = False
                 if send:
                     send_telegram_alert(alert_message.format(ip=ip, dnsbl=dnsbl))

--- a/blacklist_monitor/templates/dnsbls.html
+++ b/blacklist_monitor/templates/dnsbls.html
@@ -6,13 +6,11 @@
     <input type="submit" value="Add">
 </form>
 <h2>Bulk Add</h2>
-<form method="post" action="{{ url_for('bulk_dnsbls') }}">
+<form method="post">
     <textarea name="dnsbls_bulk" rows="4" cols="40" placeholder="one DNSBL per line" class="telegram-input"></textarea>
     <br>
-    <input type="submit" value="Add List">
-</form>
-<form method="post" action="{{ url_for('delete_selected_dnsbls') }}">
-    <button type="submit">Delete Selected</button>
+    <button type="submit" formaction="{{ url_for('bulk_dnsbls') }}">Add List</button>
+    <button type="submit" formaction="{{ url_for('delete_selected_dnsbls') }}">Delete Selected</button>
     <table>
         <tr><th><input type="checkbox" onclick="toggleAll(this)"></th><th>DNSBL</th></tr>
         {% for dnsbl in dnsbls %}

--- a/blacklist_monitor/templates/telegram.html
+++ b/blacklist_monitor/templates/telegram.html
@@ -31,8 +31,10 @@
     <input type="text" name="alert_message" value="{{ message }}" class="telegram-input">
     <br>
     <label>Resend period:</label>
-    <input type="number" name="resend_hours" value="0" placeholder="{{ resend_hours }}" min="0" class="telegram-input"> h
-    <input type="number" name="resend_minutes" value="0" placeholder="{{ resend_minutes }}" min="0" max="59" class="telegram-input"> m (0 = none)
+    <input type="number" name="resend_hours" value="0" placeholder="{{ resend_hours }}" min="0" class="telegram-input"> hours
+    <input type="number" name="resend_minutes" value="0" placeholder="{{ resend_minutes }}" min="0" max="59" class="telegram-input"> minutes (0 = none)
+    <br>
+    <small>Current resend period: {{ resend_hours }} hours {{ resend_minutes }} minutes</small>
     <br>
     <button type="submit">Save</button>
     <button type="submit" name="action" value="Test">Test</button>


### PR DESCRIPTION
## Summary
- display blacklist checks using server time
- move Delete Selected next to Add List
- clarify resend period labels and show current period

## Testing
- `python -m py_compile blacklist_monitor/app.py`

------
https://chatgpt.com/codex/tasks/task_e_68664bbd12388321be387723ca0d49d3