### PR TITLE
Increase resend period text size

### DIFF
--- a/blacklist_monitor/templates/telegram.html
+++ b/blacklist_monitor/templates/telegram.html
@@ -34,7 +34,7 @@
     <input type="number" name="resend_hours" value="0" placeholder="{{ resend_hours }}" min="0" class="telegram-input"> hours
     <input type="number" name="resend_minutes" value="0" placeholder="{{ resend_minutes }}" min="0" max="59" class="telegram-input"> minutes (0 = none)
     <br>
-    <small>Current resend period: {{ resend_hours }} hours {{ resend_minutes }} minutes</small>
+    <p>Current resend period: {{ resend_hours }} hours {{ resend_minutes }} minutes</p>
     <br>
     <button type="submit">Save</button>
     <button type="submit" name="action" value="Test">Test</button>


### PR DESCRIPTION
## Summary
- adjust Telegram settings template to display the current resend period text as a normal paragraph

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6867319154d48321a84eb6d54d507c38