### PR TITLE
Enhance Telegram alerts and tweak UI

### DIFF
--- a/blacklist_monitor/static/style.css
+++ b/blacklist_monitor/static/style.css
@@ -63,6 +63,11 @@ button, input[type="submit"] {
     border: 1px solid #ccc;
     border-radius: 4px;
 }
+.wide-select {
+    padding: 0.4em;
+    margin: 0.2em 0;
+    width: 300px;
+}
 .row-listed { background-color: #ffe6e6; }
 .row-clean { background-color: #e6ffe6; }
 .row-unknown { background-color: #f9f9f9; }

--- a/blacklist_monitor/templates/dnsbls.html
+++ b/blacklist_monitor/templates/dnsbls.html
@@ -11,6 +11,7 @@
     <br>
     <button type="submit" formaction="{{ url_for('bulk_dnsbls') }}">Add List</button>
     <button type="submit" formaction="{{ url_for('delete_selected_dnsbls') }}">Delete Selected</button>
+    <br><br>
     <table>
         <tr><th><input type="checkbox" onclick="toggleAll(this)"></th><th>DNSBL</th></tr>
         {% for dnsbl in dnsbls %}

--- a/blacklist_monitor/templates/groups.html
+++ b/blacklist_monitor/templates/groups.html
@@ -5,6 +5,7 @@
     <input type="text" name="group" placeholder="Group name" required class="telegram-input">
     <input type="submit" value="Add">
 </form>
+<br>
 <table>
     <tr><th>Group</th><th>Actions</th></tr>
     {% for g in groups %}

--- a/blacklist_monitor/templates/ips.html
+++ b/blacklist_monitor/templates/ips.html
@@ -3,7 +3,7 @@
 <h1>IP Addresses</h1>
 <form method="post">
     <input type="text" name="ip" placeholder="IP or CIDR range" required class="telegram-input">
-    <select name="group_id">
+    <select name="group_id" class="wide-select">
         <option value="">No Group</option>
         {% for g in groups %}
         <option value="{{ g[0] }}">{{ g[1] }}</option>
@@ -15,7 +15,7 @@
 <form method="post" action="{{ url_for('bulk_ips') }}">
     <textarea name="ips_bulk" rows="4" cols="40" placeholder="one IP or CIDR per line" class="telegram-input"></textarea>
     <br>
-    <select name="group_id">
+    <select name="group_id" class="wide-select">
         <option value="">No Group</option>
         {% for g in groups %}
         <option value="{{ g[0] }}">{{ g[1] }}</option>
@@ -24,7 +24,7 @@
     <input type="submit" value="Add List">
 </form>
 <form method="post" id="group-form" action="{{ url_for('set_group') }}">
-    <select name="group_id">
+    <select name="group_id" class="wide-select">
         <option value="">Ungroup</option>
         {% for g in groups %}
         <option value="{{ g[0] }}">{{ g[1] }}</option>

--- a/blacklist_monitor/templates/telegram.html
+++ b/blacklist_monitor/templates/telegram.html
@@ -9,6 +9,9 @@
     <label>Chat ID:</label>
     <input type="text" name="chat_id" class="telegram-input">
     <label><input type="checkbox" name="active" checked> Active</label>
+    <input type="text" name="alert_message" placeholder="Alert message (optional)" class="telegram-input">
+    <input type="number" name="resend_hours" value="0" min="0" class="telegram-input" placeholder="hours">
+    <input type="number" name="resend_minutes" value="0" min="0" max="59" class="telegram-input" placeholder="minutes">
     <button type="submit">Add</button>
 </form>
 
@@ -19,8 +22,12 @@
     <input type="text" name="token" value="{{ c[1] }}" class="telegram-input">
     <input type="text" name="chat_id" value="{{ c[2] }}" class="telegram-input">
     <label><input type="checkbox" name="active" {% if c[3] %}checked{% endif %}> Active</label>
+    <input type="text" name="alert_message" value="{{ c[4] }}" placeholder="default message" class="telegram-input">
+    <input type="number" name="resend_hours" value="{{ c[5] }}" min="0" class="telegram-input"> hours
+    <input type="number" name="resend_minutes" value="{{ c[6] }}" min="0" max="59" class="telegram-input"> minutes
     <button type="submit" name="action" value="Update">Update</button>
     <button type="submit" name="action" value="Delete">Delete</button>
+    <button type="submit" name="action" value="Test">Test</button>
 </form>
 {% endfor %}
 
@@ -29,7 +36,7 @@
     <input type="hidden" name="action" value="SaveMsg">
     <label>Alert Message:</label>
     <input type="text" name="alert_message" value="{{ message }}" class="telegram-input">
-    <br>
+    <br><br>
     <label>Resend period:</label>
     <input type="number" name="resend_hours" value="0" placeholder="{{ resend_hours }}" min="0" class="telegram-input"> hours
     <input type="number" name="resend_minutes" value="0" placeholder="{{ resend_minutes }}" min="0" max="59" class="telegram-input"> minutes (0 = none)


### PR DESCRIPTION
## Summary
- allow per-chat alert message and resend period
- enlarge dropdowns in IPs page
- add spacing in DNSBLs, Groups, and Telegram pages
- extend Telegram page to configure per-chat alert settings

## Testing
- `python -m py_compile blacklist_monitor/app.py`

------
https://chatgpt.com/codex/tasks/task_e_68673563d4f48321858c594f082b3297