### PR TITLE
Fix telegram buttons location

### DIFF
--- a/blacklist_monitor/templates/telegram.html
+++ b/blacklist_monitor/templates/telegram.html
@@ -17,6 +17,13 @@
 
 <h2>Saved Chats</h2>
 <form method="post">
+    <div>
+        <button type="submit" name="action" value="Activate">Activate</button>
+        <button type="submit" name="action" value="Deactivate">Deactivate</button>
+        <button type="submit" name="action" value="Update">Update</button>
+        <button type="submit" name="action" value="Delete">Delete</button>
+        <button type="submit" name="action" value="Test">Test</button>
+    </div>
     <table>
         <thead>
             <tr>
@@ -43,12 +50,5 @@
         {% endfor %}
         </tbody>
     </table>
-    <div>
-        <button type="submit" name="action" value="Activate">Activate</button>
-        <button type="submit" name="action" value="Deactivate">Deactivate</button>
-        <button type="submit" name="action" value="Update">Update</button>
-        <button type="submit" name="action" value="Delete">Delete</button>
-        <button type="submit" name="action" value="Test">Test</button>
-    </div>
 </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- rearrange action buttons on Telegram settings page

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68673d142a288321ac358114fef833d5