### PR TITLE
Add spacing around Telegram buttons

### DIFF
--- a/blacklist_monitor/static/style.css
+++ b/blacklist_monitor/static/style.css
@@ -74,3 +74,8 @@ button, input[type="submit"] {
 .row-excluded { opacity: 0.6; }
 .status-listed { color: #b00000; font-weight: bold; }
 .status-clean { color: #009000; }
+
+/* Add spacing between the action buttons and the table */
+.action-buttons {
+    margin-bottom: 1em;
+}

--- a/blacklist_monitor/templates/telegram.html
+++ b/blacklist_monitor/templates/telegram.html
@@ -17,7 +17,7 @@
 
 <h2>Saved Chats</h2>
 <form method="post">
-    <div>
+    <div class="action-buttons">
         <button type="submit" name="action" value="Activate">Activate</button>
         <button type="submit" name="action" value="Deactivate">Deactivate</button>
         <button type="submit" name="action" value="Update">Update</button>


### PR DESCRIPTION
## Summary
- tweak Telegram page styles
- add `action-buttons` class for Telegram page buttons

## Testing
- `python -m py_compile blacklist_monitor/app.py`

------
https://chatgpt.com/codex/tasks/task_e_68673e28674c832193e99d4159f3747d