### PR TITLE
Add bulk group management with checkboxes

### DIFF
--- a/blacklist_monitor/app.py
+++ b/blacklist_monitor/app.py
@@ -285,6 +285,37 @@ def update_group(group_id):
     return redirect(url_for('manage_groups'))
 
 
+@app.route('/groups/update_selected', methods=['POST'])
+def update_selected_groups():
+    ids = request.form.getlist('group_id')
+    with sqlite3.connect(DB_PATH) as conn:
+        c = conn.cursor()
+        for gid in ids:
+            name = request.form.get(f'group_name_{gid}', '').strip()
+            if name:
+                try:
+                    c.execute('UPDATE ip_groups SET name=? WHERE id=?', (name, gid))
+                except sqlite3.Error:
+                    pass
+        conn.commit()
+    return redirect(url_for('manage_groups'))
+
+
+@app.route('/groups/delete_selected', methods=['POST'])
+def delete_selected_groups():
+    ids = request.form.getlist('group_id')
+    with sqlite3.connect(DB_PATH) as conn:
+        c = conn.cursor()
+        for gid in ids:
+            try:
+                c.execute('DELETE FROM ip_groups WHERE id=?', (gid,))
+                c.execute('UPDATE ip_addresses SET group_id=NULL WHERE group_id=?', (gid,))
+            except sqlite3.Error:
+                pass
+        conn.commit()
+    return redirect(url_for('manage_groups'))
+
+
 @app.route('/ips/set_group', methods=['POST'])
 def set_group():
     group_id = request.form.get('group_id') or None

--- a/blacklist_monitor/templates/groups.html
+++ b/blacklist_monitor/templates/groups.html
@@ -1,27 +1,27 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Groups</h1>
-<form method="post">
+<form method="post" class="action-buttons">
     <input type="text" name="group" placeholder="Group name" required class="telegram-input">
     <input type="submit" value="Add">
 </form>
-<br>
-<table>
-    <tr><th>Group</th><th>Actions</th></tr>
-    {% for g in groups %}
-    <tr>
-        <td>
-            <form method="post" action="{{ url_for('update_group', group_id=g[0]) }}">
-                <input type="text" name="group_name" value="{{ g[1] }}" class="telegram-input">
-                <button type="submit">Update</button>
-            </form>
-        </td>
-        <td>
-            <form method="post" action="{{ url_for('delete_group', group_id=g[0]) }}">
-                <button type="submit">Delete</button>
-            </form>
-        </td>
-    </tr>
-    {% endfor %}
-</table>
+
+<form method="post" id="groups-form">
+    <div class="action-buttons">
+        <button type="submit" formaction="{{ url_for('update_selected_groups') }}">Update Selected</button>
+        <button type="submit" formaction="{{ url_for('delete_selected_groups') }}">Delete Selected</button>
+    </div>
+    <table>
+        <tr>
+            <th><input type="checkbox" onclick="toggleAll(this)"></th>
+            <th>Group</th>
+        </tr>
+        {% for g in groups %}
+        <tr>
+            <td><input type="checkbox" name="group_id" value="{{ g[0] }}"></td>
+            <td><input type="text" name="group_name_{{ g[0] }}" value="{{ g[1] }}" class="telegram-input"></td>
+        </tr>
+        {% endfor %}
+    </table>
+</form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- update Groups page layout
- add bulk update and delete endpoints for groups
- support selecting groups with checkboxes and one checkbox to toggle all

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6867845ce690832185880dfd71ce3131