### PR TITLE
Adjust Telegram page layout

### DIFF
--- a/blacklist_monitor/static/style.css
+++ b/blacklist_monitor/static/style.css
@@ -63,6 +63,13 @@ button, input[type="submit"] {
     border: 1px solid #ccc;
     border-radius: 4px;
 }
+.telegram-time-input {
+    padding: 0.4em;
+    margin: 0.2em 0;
+    width: 80px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
 .wide-select {
     padding: 0.4em;
     margin: 0.2em 0;

--- a/blacklist_monitor/templates/telegram.html
+++ b/blacklist_monitor/templates/telegram.html
@@ -12,8 +12,9 @@
     <input type="text" name="chat_name" class="telegram-input">
     <label><input type="checkbox" name="active" checked> Active</label>
     <input type="text" name="alert_message" value="{{ message }}" class="telegram-input">
-    <input type="number" name="resend_hours" value="{{ resend_hours }}" min="0" class="telegram-input" placeholder="hours">
-    <input type="number" name="resend_minutes" value="{{ resend_minutes }}" min="0" max="59" class="telegram-input" placeholder="minutes">
+    <input type="number" name="resend_hours" value="{{ resend_hours }}" min="0" class="telegram-time-input" placeholder="hours">
+    <input type="number" name="resend_minutes" value="{{ resend_minutes }}" min="0" max="59" class="telegram-time-input" placeholder="minutes">
+    <br>
     <button type="submit">Add</button>
 </form>
 
@@ -30,9 +31,9 @@
         <thead>
             <tr>
                 <th><input type="checkbox" onclick="toggleAll(this)"></th>
+                <th>Name</th>
                 <th>Bot Token</th>
                 <th>Chat ID</th>
-                <th>Name</th>
                 <th>Active</th>
                 <th>Alert Message</th>
                 <th>Hours</th>
@@ -43,13 +44,13 @@
         {% for c in chats %}
             <tr>
                 <td><input type="checkbox" name="chat_id" value="{{ c[0] }}"></td>
+                <td><input type="text" name="chatname_{{ c[0] }}" value="{{ c[3] }}" class="telegram-input"></td>
                 <td><input type="text" name="token_{{ c[0] }}" value="{{ c[1] }}" class="telegram-input"></td>
                 <td><input type="text" name="chatid_{{ c[0] }}" value="{{ c[2] }}" class="telegram-input"></td>
-                <td><input type="text" name="chatname_{{ c[0] }}" value="{{ c[3] }}" class="telegram-input"></td>
                 <td><input type="checkbox" name="active_{{ c[0] }}" {% if c[4] %}checked{% endif %}></td>
                 <td><input type="text" name="alert_message_{{ c[0] }}" value="{{ c[5] }}" placeholder="{{ message }}" class="telegram-input"></td>
-                <td><input type="number" name="resend_hours_{{ c[0] }}" value="{{ c[6] }}" min="0" class="telegram-input" style="width:80px"></td>
-                <td><input type="number" name="resend_minutes_{{ c[0] }}" value="{{ c[7] }}" min="0" max="59" class="telegram-input" style="width:80px"></td>
+                <td><input type="number" name="resend_hours_{{ c[0] }}" value="{{ c[6] }}" min="0" class="telegram-time-input"></td>
+                <td><input type="number" name="resend_minutes_{{ c[0] }}" value="{{ c[7] }}" min="0" max="59" class="telegram-time-input"></td>
             </tr>
         {% endfor %}
         </tbody>


### PR DESCRIPTION
## Summary
- tighten hours/minutes inputs so Add New form fits on one row
- move Add button to its own line
- reorder Telegram table so chat name shows after the checkbox

## Testing
- `python -m py_compile app.py`
- `flake8 || true`

------
https://chatgpt.com/codex/tasks/task_e_68679ad9ab5083218acf8d8293a13b98