### PR TITLE
Enhance backup scheduling

### DIFF
--- a/blacklist_monitor/static/script.js
+++ b/blacklist_monitor/static/script.js
@@ -26,3 +26,26 @@ function toggleAll(src) {
 }
 
 window.addEventListener('load', restoreCollapse);
+
+function updateScheduleInputs() {
+  const type = document.getElementById('schedule-type');
+  if (!type) return;
+  const weekly = document.getElementById('day-weekly');
+  const monthly = document.getElementById('day-monthly');
+  if (weekly) weekly.style.display = 'none';
+  if (monthly) monthly.style.display = 'none';
+  if (type.value === 'weekly') {
+    if (weekly) weekly.style.display = '';
+    if (weekly) weekly.querySelector('select').disabled = false;
+    if (monthly) monthly.querySelector('input').disabled = true;
+  } else if (type.value === 'monthly') {
+    if (monthly) monthly.style.display = '';
+    if (monthly) monthly.querySelector('input').disabled = false;
+    if (weekly) weekly.querySelector('select').disabled = true;
+  } else {
+    if (weekly) weekly.querySelector('select').disabled = true;
+    if (monthly) monthly.querySelector('input').disabled = true;
+  }
+}
+
+window.addEventListener('load', updateScheduleInputs);

--- a/blacklist_monitor/static/style.css
+++ b/blacklist_monitor/static/style.css
@@ -86,3 +86,8 @@ button, input[type="submit"] {
 .action-buttons {
     margin-bottom: 1.5em;
 }
+
+#day-weekly,
+#day-monthly {
+    display: none;
+}

--- a/blacklist_monitor/templates/backups.html
+++ b/blacklist_monitor/templates/backups.html
@@ -13,22 +13,61 @@
     <button type="submit">Run Backup Now</button>
 </form>
 <h2>Schedule</h2>
-<form method="post">
-    <input type="hidden" name="action" value="schedule">
-    <label>Type:</label>
-    <select name="type" class="wide-select">
-        <option value="" {% if sched_type == '' %}selected{% endif %}>None</option>
-        <option value="daily" {% if sched_type == 'daily' %}selected{% endif %}>Daily</option>
-        <option value="weekly" {% if sched_type == 'weekly' %}selected{% endif %}>Weekly</option>
-        <option value="monthly" {% if sched_type == 'monthly' %}selected{% endif %}>Monthly</option>
+<form method="post" id="schedule-form">
+    <input type="hidden" name="action" value="schedule_add">
+    <label>Group:</label>
+    <select name="group_id" class="wide-select">
+        <option value="">All Groups</option>
+        {% for g in groups %}
+        <option value="{{ g[0] }}">{{ g[1] }}</option>
+        {% endfor %}
     </select>
-    <label>Day:</label>
-    <input type="text" name="day" value="{{ sched_day }}" class="telegram-input">
-    <label>Hour:</label>
-    <input type="number" name="hour" value="{{ sched_hour }}" min="0" max="23" class="telegram-input">
-    <label>Minute:</label>
-    <input type="number" name="minute" value="{{ sched_minute }}" min="0" max="59" class="telegram-input">
-    <input type="submit" value="Update">
+    <label>Type:</label>
+    <select name="type" id="schedule-type" class="wide-select" onchange="updateScheduleInputs()">
+        <option value="daily">Daily</option>
+        <option value="weekly">Weekly</option>
+        <option value="monthly">Monthly</option>
+    </select>
+    <span id="day-weekly">
+        <select name="day" class="wide-select">
+            <option value="mon">Mon</option>
+            <option value="tue">Tue</option>
+            <option value="wed">Wed</option>
+            <option value="thu">Thu</option>
+            <option value="fri">Fri</option>
+            <option value="sat">Sat</option>
+            <option value="sun">Sun</option>
+        </select>
+    </span>
+    <span id="day-monthly">
+        <input type="number" name="day" min="1" max="31" class="telegram-time-input">
+    </span>
+    <label>Time:</label>
+    <input type="number" name="hour" min="1" max="12" class="telegram-time-input">
+    <input type="number" name="minute" min="0" max="59" class="telegram-time-input">
+    <select name="ampm" class="telegram-input">
+        <option value="am">AM</option>
+        <option value="pm">PM</option>
+    </select>
+    <button type="submit">Add</button>
+</form>
+<form method="post">
+    <input type="hidden" name="action" value="schedule_delete">
+    <div class="action-buttons">
+        <button type="submit">Delete Selected</button>
+    </div>
+    <table>
+        <tr><th><input type="checkbox" onclick="toggleAll(this)"></th><th>Group</th><th>Type</th><th>Day</th><th>Time</th></tr>
+        {% for s in schedules %}
+        <tr>
+            <td><input type="checkbox" name="schedule_id" value="{{ s[0] }}"></td>
+            <td>{{ s[1] or 'All' }}</td>
+            <td>{{ s[2] }}</td>
+            <td>{{ s[3] }}</td>
+            <td>{{ s[4] }}</td>
+        </tr>
+        {% endfor %}
+    </table>
 </form>
 <h2>Retention</h2>
 <form method="post">
@@ -40,7 +79,9 @@
 <h2>Existing Backups</h2>
 <form method="post">
     <input type="hidden" name="action" value="delete">
-    <button type="submit">Delete Selected</button>
+    <div class="action-buttons">
+        <button type="submit">Delete Selected</button>
+    </div>
     <table>
         <tr><th><input type="checkbox" onclick="toggleAll(this)"></th><th>ID</th><th>Date</th><th>Status</th><th>Error</th></tr>
         {% for b in backups %}


### PR DESCRIPTION
## Summary
- support multiple backup schedules per IP group
- store schedules in new `backup_schedules` table
- show schedules on Backup page and allow deletion
- use AM/PM time input and day pickers
- add schedule JS helpers and default hidden CSS elements
- add spacing around Delete Selected button

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686b4549e57c8321882994586ffd2830