### PR TITLE
Update backup scheduler UI

### DIFF
--- a/blacklist_monitor/static/script.js
+++ b/blacklist_monitor/static/script.js
@@ -27,39 +27,61 @@ function toggleAll(src) {
 
 window.addEventListener('load', restoreCollapse);
 
-function handleScheduleInputs(typeId, weeklyId, monthlyId) {
-  const type = document.getElementById(typeId);
-  if (!type) return;
-  const weekly = document.getElementById(weeklyId);
-  const monthly = document.getElementById(monthlyId);
-  if (weekly) weekly.style.display = 'none';
-  if (monthly) monthly.style.display = 'none';
-  if (type.value === 'weekly') {
-    if (weekly) weekly.style.display = '';
-    if (weekly) weekly.querySelector('select').disabled = false;
-    if (monthly) monthly.querySelector('input').disabled = true;
-  } else if (type.value === 'monthly') {
-    if (monthly) monthly.style.display = '';
-    if (monthly) monthly.querySelector('input').disabled = false;
-    if (weekly) weekly.querySelector('select').disabled = true;
-  } else {
-    if (weekly) weekly.querySelector('select').disabled = true;
-    if (monthly) monthly.querySelector('input').disabled = true;
+function updateScheduleDisplay(prefix) {
+  const daily = document.getElementById(prefix + '-daily');
+  const weekly = document.getElementById(prefix + '-weekly');
+  const monthly = document.getElementById(prefix + '-monthly');
+  const hidden = document.getElementById(prefix + '-type');
+  const weeklyWrap = document.getElementById(prefix + '-day-weekly');
+  const monthlyWrap = document.getElementById(prefix + '-day-monthly');
+
+  if (hidden) {
+    if (daily && daily.checked) hidden.value = 'daily';
+    else if (weekly && weekly.checked) hidden.value = 'weekly';
+    else if (monthly && monthly.checked) hidden.value = 'monthly';
+    else hidden.value = '';
+  }
+
+  if (weeklyWrap) {
+    const show = weekly && weekly.checked;
+    weeklyWrap.style.display = show ? '' : 'none';
+    const sel = weeklyWrap.querySelector('select');
+    if (sel) sel.disabled = !show;
+  }
+
+  if (monthlyWrap) {
+    const show = monthly && monthly.checked;
+    monthlyWrap.style.display = show ? '' : 'none';
+    const inp = monthlyWrap.querySelector('input');
+    if (inp) inp.disabled = !show;
   }
 }
 
-function updateScheduleInputs() {
-  handleScheduleInputs('schedule-type', 'day-weekly', 'day-monthly');
-}
+function selectType(prefix, type) {
+  const daily = document.getElementById(prefix + '-daily');
+  const weekly = document.getElementById(prefix + '-weekly');
+  const monthly = document.getElementById(prefix + '-monthly');
 
-function updateRowScheduleInputs(id) {
-  handleScheduleInputs('row-' + id + '-type', 'row-' + id + '-day-weekly', 'row-' + id + '-day-monthly');
+  if (type === 'daily') {
+    if (daily) daily.checked = true;
+    if (weekly) weekly.checked = false;
+    if (monthly) monthly.checked = false;
+  } else if (type === 'weekly') {
+    if (daily) daily.checked = false;
+    if (weekly) weekly.checked = true;
+    if (monthly) monthly.checked = false;
+  } else if (type === 'monthly') {
+    if (daily) daily.checked = false;
+    if (weekly) weekly.checked = false;
+    if (monthly) monthly.checked = true;
+  }
+  updateScheduleDisplay(prefix);
 }
 
 window.addEventListener('load', function() {
-  updateScheduleInputs();
-  document.querySelectorAll('.schedule-type-row').forEach(function(el) {
-    const id = el.dataset.rowId;
-    updateRowScheduleInputs(id);
+  updateScheduleDisplay('schedule');
+  document.querySelectorAll('.schedule-row').forEach(function(row) {
+    const id = row.dataset.rowId;
+    updateScheduleDisplay('row-' + id);
   });
 });

--- a/blacklist_monitor/static/style.css
+++ b/blacklist_monitor/static/style.css
@@ -100,3 +100,16 @@ button, input[type="submit"] {
     border-collapse: separate;
     border-spacing: 0 0.5em;
 }
+
+/* shorter controls for schedule page */
+.short-select {
+    width: 150px;
+    padding: 0.4em;
+    margin: 0.2em 0;
+}
+
+.ampm-select {
+    width: 80px;
+    padding: 0.4em;
+    margin: 0.2em 0;
+}

--- a/blacklist_monitor/templates/backups.html
+++ b/blacklist_monitor/templates/backups.html
@@ -19,19 +19,17 @@
     <input type="hidden" name="schedule_id" value="{{ edit_schedule.id }}">
     {% endif %}
     <label>Group:</label>
-    <select name="group_id" class="wide-select">
+    <select name="group_id" class="short-select">
         <option value="">All Groups</option>
         {% for g in groups %}
         <option value="{{ g[0] }}" {% if edit_schedule and g[0]==edit_schedule.group_id %}selected{% endif %}>{{ g[1] }}</option>
         {% endfor %}
     </select>
-    <label>Type:</label>
-    <select name="type" id="schedule-type" class="wide-select" onchange="updateScheduleInputs()">
-        <option value="daily" {% if edit_schedule and edit_schedule.type=='daily' %}selected{% endif %}>Daily</option>
-        <option value="weekly" {% if edit_schedule and edit_schedule.type=='weekly' %}selected{% endif %}>Weekly</option>
-        <option value="monthly" {% if edit_schedule and edit_schedule.type=='monthly' %}selected{% endif %}>Monthly</option>
-    </select>
-    <span id="day-weekly">
+    <input type="hidden" name="type" id="schedule-type" value="{{ edit_schedule.type if edit_schedule else 'daily' }}">
+    <label><input type="checkbox" id="schedule-daily" onclick="selectType('schedule','daily')" {% if not edit_schedule or edit_schedule.type=='daily' %}checked{% endif %}>Daily</label>
+    <label><input type="checkbox" id="schedule-weekly" onclick="selectType('schedule','weekly')" {% if edit_schedule and edit_schedule.type=='weekly' %}checked{% endif %}>Weekly</label>
+    <label><input type="checkbox" id="schedule-monthly" onclick="selectType('schedule','monthly')" {% if edit_schedule and edit_schedule.type=='monthly' %}checked{% endif %}>Monthly</label>
+    <span id="schedule-day-weekly">
         <select name="day" class="wide-select">
             <option value="mon" {% if edit_schedule and edit_schedule.type=='weekly' and edit_schedule.day=='mon' %}selected{% endif %}>Mon</option>
             <option value="tue" {% if edit_schedule and edit_schedule.type=='weekly' and edit_schedule.day=='tue' %}selected{% endif %}>Tue</option>
@@ -42,13 +40,13 @@
             <option value="sun" {% if edit_schedule and edit_schedule.type=='weekly' and edit_schedule.day=='sun' %}selected{% endif %}>Sun</option>
         </select>
     </span>
-    <span id="day-monthly">
+    <span id="schedule-day-monthly">
         <input type="date" name="day" class="telegram-time-input" {% if edit_schedule and edit_schedule.type=='monthly' %}value="{{ edit_schedule.date_value }}"{% endif %}>
     </span>
     <label>Time:</label>
     <input type="number" name="hour" min="1" max="12" class="telegram-time-input" {% if edit_schedule %}value="{{ edit_schedule.hour }}"{% endif %}>
     <input type="number" name="minute" min="0" max="59" class="telegram-time-input" {% if edit_schedule %}value="{{ edit_schedule.minute }}"{% endif %}>
-    <select name="ampm" class="telegram-input">
+    <select name="ampm" class="ampm-select">
         <option value="am" {% if edit_schedule and edit_schedule.ampm=='am' %}selected{% endif %}>AM</option>
         <option value="pm" {% if edit_schedule and edit_schedule.ampm=='pm' %}selected{% endif %}>PM</option>
     </select>
@@ -69,10 +67,10 @@
             <th>Time</th>
         </tr>
         {% for s in schedules %}
-        <tr>
+        <tr class="schedule-row" data-row-id="{{ s.id }}">
             <td><input type="checkbox" name="schedule_id" value="{{ s.id }}"></td>
             <td>
-                <select name="group_id_{{ s.id }}" class="wide-select">
+                <select name="group_id_{{ s.id }}" class="short-select">
                     <option value="">All Groups</option>
                     {% for g in groups %}
                     <option value="{{ g[0] }}" {% if s.group_id==g[0] %}selected{% endif %}>{{ g[1] }}</option>
@@ -80,11 +78,10 @@
                 </select>
             </td>
             <td>
-                <select name="type_{{ s.id }}" id="row-{{ s.id }}-type" class="wide-select schedule-type-row" data-row-id="{{ s.id }}" onchange="updateRowScheduleInputs('{{ s.id }}')">
-                    <option value="daily" {% if s.type=='daily' %}selected{% endif %}>Daily</option>
-                    <option value="weekly" {% if s.type=='weekly' %}selected{% endif %}>Weekly</option>
-                    <option value="monthly" {% if s.type=='monthly' %}selected{% endif %}>Monthly</option>
-                </select>
+                <input type="hidden" name="type_{{ s.id }}" id="row-{{ s.id }}-type" value="{{ s.type }}">
+                <label><input type="checkbox" id="row-{{ s.id }}-daily" onclick="selectType('row-{{ s.id }}','daily')" {% if s.type=='daily' %}checked{% endif %}>Daily</label>
+                <label><input type="checkbox" id="row-{{ s.id }}-weekly" onclick="selectType('row-{{ s.id }}','weekly')" {% if s.type=='weekly' %}checked{% endif %}>Weekly</label>
+                <label><input type="checkbox" id="row-{{ s.id }}-monthly" onclick="selectType('row-{{ s.id }}','monthly')" {% if s.type=='monthly' %}checked{% endif %}>Monthly</label>
             </td>
             <td>
                 <span id="row-{{ s.id }}-day-weekly">
@@ -105,7 +102,7 @@
             <td>
                 <input type="number" name="hour_{{ s.id }}" min="1" max="12" class="telegram-time-input" value="{{ s.hour }}">
                 <input type="number" name="minute_{{ s.id }}" min="0" max="59" class="telegram-time-input" value="{{ s.minute }}">
-                <select name="ampm_{{ s.id }}" class="telegram-input">
+                <select name="ampm_{{ s.id }}" class="ampm-select">
                     <option value="am" {% if s.ampm=='AM' %}selected{% endif %}>AM</option>
                     <option value="pm" {% if s.ampm=='PM' %}selected{% endif %}>PM</option>
                 </select>


### PR DESCRIPTION
## Summary
- revamp backup schedule form with checkbox controls
- shorten schedule dropdown widths
- adjust JS logic for new schedule options

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686b67c6120c8321ad75c78680dbdfde