### PR TITLE
Implement backup view and UI tweaks

### DIFF
--- a/blacklist_monitor/static/style.css
+++ b/blacklist_monitor/static/style.css
@@ -113,3 +113,20 @@ button, input[type="submit"] {
     padding: 0.4em;
     margin: 0.2em 0;
 }
+
+/* wider date selector for schedule calendar */
+.date-input {
+    width: 180px;
+}
+
+/* shorter day dropdown */
+.day-select {
+    width: 120px;
+}
+
+/* spacing for add schedule row */
+#schedule-form label,
+#schedule-form input,
+#schedule-form select {
+    margin-right: 0.5em;
+}

--- a/blacklist_monitor/templates/backups.html
+++ b/blacklist_monitor/templates/backups.html
@@ -30,7 +30,7 @@
     <label><input type="checkbox" id="schedule-weekly" onclick="selectType('schedule','weekly')" {% if edit_schedule and edit_schedule.type=='weekly' %}checked{% endif %}>Weekly</label>
     <label><input type="checkbox" id="schedule-monthly" onclick="selectType('schedule','monthly')" {% if edit_schedule and edit_schedule.type=='monthly' %}checked{% endif %}>Monthly</label>
     <span id="schedule-day-weekly">
-        <select name="day" class="wide-select">
+        <select name="day" class="day-select">
             <option value="mon" {% if edit_schedule and edit_schedule.type=='weekly' and edit_schedule.day=='mon' %}selected{% endif %}>Mon</option>
             <option value="tue" {% if edit_schedule and edit_schedule.type=='weekly' and edit_schedule.day=='tue' %}selected{% endif %}>Tue</option>
             <option value="wed" {% if edit_schedule and edit_schedule.type=='weekly' and edit_schedule.day=='wed' %}selected{% endif %}>Wed</option>
@@ -41,7 +41,7 @@
         </select>
     </span>
     <span id="schedule-day-monthly">
-        <input type="date" name="day" class="telegram-time-input" {% if edit_schedule and edit_schedule.type=='monthly' %}value="{{ edit_schedule.date_value }}"{% endif %}>
+        <input type="date" name="day" class="telegram-time-input date-input" {% if edit_schedule and edit_schedule.type=='monthly' %}value="{{ edit_schedule.date_value }}"{% endif %}>
     </span>
     <label>Time:</label>
     <input type="number" name="hour" min="1" max="12" class="telegram-time-input" {% if edit_schedule %}value="{{ edit_schedule.hour }}"{% endif %}>
@@ -85,7 +85,7 @@
             </td>
             <td>
                 <span id="row-{{ s.id }}-day-weekly">
-                    <select name="day_{{ s.id }}" class="wide-select">
+                    <select name="day_{{ s.id }}" class="day-select">
                         <option value="mon" {% if s.type=='weekly' and s.day=='mon' %}selected{% endif %}>Mon</option>
                         <option value="tue" {% if s.type=='weekly' and s.day=='tue' %}selected{% endif %}>Tue</option>
                         <option value="wed" {% if s.type=='weekly' and s.day=='wed' %}selected{% endif %}>Wed</option>
@@ -96,7 +96,7 @@
                     </select>
                 </span>
                 <span id="row-{{ s.id }}-day-monthly">
-                    <input type="date" name="day_{{ s.id }}" class="telegram-time-input" {% if s.type=='monthly' and s.day %}value="{{ '2000-01-' + '%02d'|format(s.day|int) }}"{% endif %}>
+                    <input type="date" name="day_{{ s.id }}" class="telegram-time-input date-input" {% if s.type=='monthly' and s.day %}value="{{ '2000-01-' + '%02d'|format(s.day|int) }}"{% endif %}>
                 </span>
             </td>
             <td>
@@ -114,15 +114,15 @@
 <h2>Retention</h2>
 <form method="post">
     <input type="hidden" name="action" value="retention">
-    <label>Keep days:</label>
+    <label>Keep days (0 to disable cleanup):</label>
     <input type="number" name="days" value="{{ retention_days }}" min="0" class="telegram-input">
     <input type="submit" value="Save">
 </form>
 <h2>Existing Backups</h2>
 <form method="post">
-    <input type="hidden" name="action" value="delete">
     <div class="action-buttons">
-        <button type="submit">Delete Selected</button>
+        <button type="submit" name="action" value="view">View Selected</button>
+        <button type="submit" name="action" value="delete">Delete Selected</button>
     </div>
     <table>
         <tr><th><input type="checkbox" onclick="toggleAll(this)"></th><th>ID</th><th>Date</th><th>Status</th><th>Error</th></tr>


### PR DESCRIPTION
## Summary
- allow viewing backup results
- display created backup in search results
- improve backup schedule form UI
- clarify retention input wording

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686b6b99f3b88321ae23d03d1ad56c49