### PR TITLE
Enhance backup UI and retention logic

### DIFF
--- a/blacklist_monitor/static/script.js
+++ b/blacklist_monitor/static/script.js
@@ -46,7 +46,11 @@ function updateScheduleDisplay(prefix) {
     const show = weekly && weekly.checked;
     weeklyWrap.style.display = show ? '' : 'none';
     const sel = weeklyWrap.querySelector('select');
-    if (sel) sel.disabled = !show;
+    if (sel) {
+      sel.disabled = !show;
+      if (show) sel.classList.add('active');
+      else sel.classList.remove('active');
+    }
   }
 
   if (monthlyWrap) {
@@ -83,5 +87,15 @@ window.addEventListener('load', function() {
   document.querySelectorAll('.schedule-row').forEach(function(row) {
     const id = row.dataset.rowId;
     updateScheduleDisplay('row-' + id);
+  });
+  document.querySelectorAll('[id$="-day-monthly"] input').forEach(function(inp) {
+    const key = 'cache_' + inp.name;
+    const saved = localStorage.getItem(key);
+    if (!inp.value && saved) {
+      inp.value = saved;
+    }
+    inp.addEventListener('change', function() {
+      localStorage.setItem(key, this.value);
+    });
   });
 });

--- a/blacklist_monitor/static/style.css
+++ b/blacklist_monitor/static/style.css
@@ -121,7 +121,13 @@ button, input[type="submit"] {
 
 /* shorter day dropdown */
 .day-select {
-    width: 120px;
+    width: 140px;
+    padding: 0.4em;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+.day-select.active {
+    background-color: #f0f8ff;
 }
 
 /* spacing for add schedule row */
@@ -129,4 +135,8 @@ button, input[type="submit"] {
 #schedule-form input,
 #schedule-form select {
     margin-right: 0.5em;
+}
+
+#search-section {
+    margin-top: 2em;
 }

--- a/blacklist_monitor/templates/backups.html
+++ b/blacklist_monitor/templates/backups.html
@@ -116,6 +116,8 @@
     <input type="hidden" name="action" value="retention">
     <label>Keep days (0 to disable cleanup):</label>
     <input type="number" name="days" value="{{ retention_days }}" min="0" class="telegram-input">
+    <label>Keep count (0 to disable limit):</label>
+    <input type="number" name="count" value="{{ retention_count }}" min="0" class="telegram-input">
     <input type="submit" value="Save">
 </form>
 <h2>Existing Backups</h2>
@@ -137,8 +139,9 @@
         {% endfor %}
     </table>
 </form>
+<div id="search-section">
 <h2>Search</h2>
-<form method="get">
+<form method="get" class="search-form">
     <label>From:</label>
     <input type="date" name="start" value="{{ request.args.start }}" class="telegram-input">
     <label>To:</label>
@@ -156,6 +159,7 @@
     <input type="submit" value="Search">
 </form>
 {% if results %}
+{% if view_id %}<h3>Backup Results</h3>{% endif %}
 <table>
 <tr><th>Date</th><th>IP</th><th>DNSBL</th><th>Listed</th><th>Checked At</th></tr>
 {% for r in results %}
@@ -169,4 +173,5 @@
 {% endfor %}
 </table>
 {% endif %}
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- style weekly day dropdown and keep value for monthly date inputs
- add `BACKUP_KEEP_COUNT` setting for number of backups to retain
- show backup results only when selected and improve search spacing

## Testing
- `python -m py_compile blacklist_monitor/app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b727f7ae88321a37218de3d51e3de