### PR TITLE
UI tweaks for backup schedules

### DIFF
--- a/blacklist_monitor/app.py
+++ b/blacklist_monitor/app.py
@@ -633,8 +633,9 @@ def backups_view():
     if request.method == 'POST':
         action = request.form.get('action', '')
         if action == 'create':
-            bid = create_backup()
-            return redirect(url_for('backups_view', view=bid or ''))
+            create_backup()
+            # redirect without view parameter so backup data is hidden
+            return redirect(url_for('backups_view'))
         elif action == 'view':
             ids = request.form.getlist('backup_id')
             if ids:
@@ -738,6 +739,9 @@ def backups_view():
                 h -= 12
         if h == 0:
             h = 12
+        date_val = ''
+        if stype == 'monthly' and day:
+            date_val = f"2000-01-{int(day):02d}"
         display_schedules.append({'id': sid,
                                  'group_id': gid,
                                  'group_name': gname,
@@ -745,7 +749,8 @@ def backups_view():
                                  'day': day,
                                  'hour': h,
                                  'minute': minute,
-                                 'ampm': ampm})
+                                 'ampm': ampm,
+                                 'date_value': date_val})
 
     edit_schedule = None
     if request.args.get('edit'):

--- a/blacklist_monitor/static/script.js
+++ b/blacklist_monitor/static/script.js
@@ -48,8 +48,8 @@ function updateScheduleDisplay(prefix) {
     const sel = weeklyWrap.querySelector('select');
     if (sel) {
       sel.disabled = !show;
-      if (show) sel.classList.add('active');
-      else sel.classList.remove('active');
+      // remove highlight color for weekly day dropdown
+      sel.classList.remove('active');
     }
   }
 

--- a/blacklist_monitor/static/style.css
+++ b/blacklist_monitor/static/style.css
@@ -126,9 +126,6 @@ button, input[type="submit"] {
     border: 1px solid #ccc;
     border-radius: 4px;
 }
-.day-select.active {
-    background-color: #f0f8ff;
-}
 
 /* spacing for add schedule row */
 #schedule-form label,

--- a/blacklist_monitor/templates/backups.html
+++ b/blacklist_monitor/templates/backups.html
@@ -96,7 +96,7 @@
                     </select>
                 </span>
                 <span id="row-{{ s.id }}-day-monthly">
-                    <input type="date" name="day_{{ s.id }}" class="telegram-time-input date-input" {% if s.type=='monthly' and s.day %}value="{{ '2000-01-' + '%02d'|format(s.day|int) }}"{% endif %}>
+                    <input type="date" name="day_{{ s.id }}" class="telegram-time-input date-input" {% if s.type=='monthly' and s.day %}value="{{ s.date_value }}"{% endif %}>
                 </span>
             </td>
             <td>


### PR DESCRIPTION
## Summary
- refine backup schedule UI, removing day dropdown highlight
- ensure schedule rows include saved monthly date value
- stop viewing results directly after running backups

## Testing
- `python -m py_compile blacklist_monitor/app.py`

------
https://chatgpt.com/codex/tasks/task_e_686b760a871c8321b17121f11cf077a5