### PR TITLE
Add group-based schedule management

### DIFF
--- a/blacklist_monitor/templates/_schedule_form.html
+++ b/blacklist_monitor/templates/_schedule_form.html
@@ -1,0 +1,99 @@
+<h1>Schedule</h2>
+<form method="post" id="schedule-form">
+    <input type="hidden" name="action" value="schedule_add">
+    {% if edit_schedule %}
+    <input type="hidden" name="schedule_id" value="{{ edit_schedule.id }}">
+    {% endif %}
+    <label>Group:</label>
+    <select name="group_id" class="short-select">
+        <option value="">All Groups</option>
+        {% for g in groups %}
+        <option value="{{ g[0] }}" {% if edit_schedule and g[0]==edit_schedule.group_id %}selected{% endif %}>{{ g[1] }}</option>
+        {% endfor %}
+    </select>
+    <input type="hidden" name="type" id="schedule-type" value="{{ edit_schedule.type if edit_schedule else 'daily' }}">
+    <label><input type="checkbox" id="schedule-daily" onclick="selectType('schedule','daily')" {% if not edit_schedule or edit_schedule.type=='daily' %}checked{% endif %}>Daily</label>
+    <label><input type="checkbox" id="schedule-weekly" onclick="selectType('schedule','weekly')" {% if edit_schedule and edit_schedule.type=='weekly' %}checked{% endif %}>Weekly</label>
+    <label><input type="checkbox" id="schedule-monthly" onclick="selectType('schedule','monthly')" {% if edit_schedule and edit_schedule.type=='monthly' %}checked{% endif %}>Monthly</label>
+    <span id="schedule-day-weekly">
+        <select name="day" class="day-select">
+            <option value="mon" {% if edit_schedule and edit_schedule.type=='weekly' and edit_schedule.day=='mon' %}selected{% endif %}>Mon</option>
+            <option value="tue" {% if edit_schedule and edit_schedule.type=='weekly' and edit_schedule.day=='tue' %}selected{% endif %}>Tue</option>
+            <option value="wed" {% if edit_schedule and edit_schedule.type=='weekly' and edit_schedule.day=='wed' %}selected{% endif %}>Wed</option>
+            <option value="thu" {% if edit_schedule and edit_schedule.type=='weekly' and edit_schedule.day=='thu' %}selected{% endif %}>Thu</option>
+            <option value="fri" {% if edit_schedule and edit_schedule.type=='weekly' and edit_schedule.day=='fri' %}selected{% endif %}>Fri</option>
+            <option value="sat" {% if edit_schedule and edit_schedule.type=='weekly' and edit_schedule.day=='sat' %}selected{% endif %}>Sat</option>
+            <option value="sun" {% if edit_schedule and edit_schedule.type=='weekly' and edit_schedule.day=='sun' %}selected{% endif %}>Sun</option>
+        </select>
+    </span>
+    <span id="schedule-day-monthly">
+        <input type="date" name="day" class="telegram-time-input date-input" {% if edit_schedule and edit_schedule.type=='monthly' %}value="{{ edit_schedule.date_value }}"{% endif %}>
+    </span>
+    <label>Time:</label>
+    <input type="number" name="hour" min="1" max="12" class="telegram-time-input" {% if edit_schedule %}value="{{ edit_schedule.hour }}"{% endif %}>
+    <input type="number" name="minute" min="0" max="59" class="telegram-time-input" {% if edit_schedule %}value="{{ edit_schedule.minute }}"{% endif %}>
+    <select name="ampm" class="ampm-select">
+        <option value="am" {% if edit_schedule and edit_schedule.ampm=='am' %}selected{% endif %}>AM</option>
+        <option value="pm" {% if edit_schedule and edit_schedule.ampm=='pm' %}selected{% endif %}>PM</option>
+    </select>
+    <button type="submit">{% if edit_schedule %}Update{% else %}Add{% endif %}</button>
+    {% if edit_schedule %}<a href="{{ url_for('schedule_view') }}">Cancel</a>{% endif %}
+</form>
+<form method="post" id="schedule-delete-form">
+    <div class="action-buttons">
+        <button type="submit" name="action" value="schedule_update">Update Selected</button>
+        <button type="submit" name="action" value="schedule_delete">Delete Selected</button>
+    </div>
+    <table class="schedule-table">
+        <tr>
+            <th><input type="checkbox" onclick="toggleAll(this)"></th>
+            <th>Group</th>
+            <th>Type</th>
+            <th>Day</th>
+            <th>Time</th>
+        </tr>
+        {% for s in schedules %}
+        <tr class="schedule-row" data-row-id="{{ s.id }}">
+            <td><input type="checkbox" name="schedule_id" value="{{ s.id }}"></td>
+            <td>
+                <select name="group_id_{{ s.id }}" class="short-select">
+                    <option value="">All Groups</option>
+                    {% for g in groups %}
+                    <option value="{{ g[0] }}" {% if s.group_id==g[0] %}selected{% endif %}>{{ g[1] }}</option>
+                    {% endfor %}
+                </select>
+            </td>
+            <td>
+                <input type="hidden" name="type_{{ s.id }}" id="row-{{ s.id }}-type" value="{{ s.type }}">
+                <label><input type="checkbox" id="row-{{ s.id }}-daily" onclick="selectType('row-{{ s.id }}','daily')" {% if s.type=='daily' %}checked{% endif %}>Daily</label>
+                <label><input type="checkbox" id="row-{{ s.id }}-weekly" onclick="selectType('row-{{ s.id }}','weekly')" {% if s.type=='weekly' %}checked{% endif %}>Weekly</label>
+                <label><input type="checkbox" id="row-{{ s.id }}-monthly" onclick="selectType('row-{{ s.id }}','monthly')" {% if s.type=='monthly' %}checked{% endif %}>Monthly</label>
+            </td>
+            <td>
+                <span id="row-{{ s.id }}-day-weekly">
+                    <select name="day_{{ s.id }}" class="day-select">
+                        <option value="mon" {% if s.type=='weekly' and s.day=='mon' %}selected{% endif %}>Mon</option>
+                        <option value="tue" {% if s.type=='weekly' and s.day=='tue' %}selected{% endif %}>Tue</option>
+                        <option value="wed" {% if s.type=='weekly' and s.day=='wed' %}selected{% endif %}>Wed</option>
+                        <option value="thu" {% if s.type=='weekly' and s.day=='thu' %}selected{% endif %}>Thu</option>
+                        <option value="fri" {% if s.type=='weekly' and s.day=='fri' %}selected{% endif %}>Fri</option>
+                        <option value="sat" {% if s.type=='weekly' and s.day=='sat' %}selected{% endif %}>Sat</option>
+                        <option value="sun" {% if s.type=='weekly' and s.day=='sun' %}selected{% endif %}>Sun</option>
+                    </select>
+                </span>
+                <span id="row-{{ s.id }}-day-monthly">
+                    <input type="date" name="day_{{ s.id }}" class="telegram-time-input date-input" {% if s.type=='monthly' and s.day %}value="{{ s.date_value }}"{% endif %}>
+                </span>
+            </td>
+            <td>
+                <input type="number" name="hour_{{ s.id }}" min="1" max="12" class="telegram-time-input" value="{{ s.hour }}">
+                <input type="number" name="minute_{{ s.id }}" min="0" max="59" class="telegram-time-input" value="{{ s.minute }}">
+                <select name="ampm_{{ s.id }}" class="ampm-select">
+                    <option value="am" {% if s.ampm=='AM' %}selected{% endif %}>AM</option>
+                    <option value="pm" {% if s.ampm=='PM' %}selected{% endif %}>PM</option>
+                </select>
+            </td>
+        </tr>
+        {% endfor %}
+    </table>
+</form>

--- a/blacklist_monitor/templates/index.html
+++ b/blacklist_monitor/templates/index.html
@@ -2,7 +2,6 @@
 {% block content %}
 <h1>Monitored IPs</h1>
 <p>Total IPs: {{ ip_count }}</p>
-<p>Next scheduled check: {{ next_run and next_run.strftime('%H:%M') }}</p>
 <form method="post" action="{{ url_for('check_selected') }}">
     <button type="submit">Check Selected</button>
     <button type="submit" formaction="{{ url_for('exclude_selected') }}">Exclude Selected</button>
@@ -11,13 +10,14 @@
         <h3 onclick="toggle('g{{ g[0] }}')" class="group-header">{{ g[1] }}</h3>
         <div id="g{{ g[0] }}" data-collapse>
         <table>
-            <tr><th><input type="checkbox" onclick="toggleAll(this)"></th><th>IP</th><th>Last Checked</th><th>Status</th><th>DNSBL</th><th>Check Excluded</th></tr>
+            <tr><th><input type="checkbox" onclick="toggleAll(this)"></th><th>IP</th><th>Last Checked</th><th>Next Run</th><th>Status</th><th>DNSBL</th><th>Check Excluded</th></tr>
             {% for ip in ips %}
                 {% if ip[3] == g[0] %}
                 <tr class="{% if ip[4] %}row-excluded{% elif ip[5] == 1 %}row-listed{% elif ip[5] == 0 %}row-clean{% else %}row-unknown{% endif %}">
                     <td><input type="checkbox" name="ip_id" value="{{ ip[0] }}"></td>
                     <td>{{ ip[1] }}</td>
                     <td>{{ ip[2] or 'never' }}</td>
+                    <td>{{ next_runs[ip[0]] }}</td>
                     <td class="{% if ip[5] == 1 %}status-listed{% elif ip[5] == 0 %}status-clean{% endif %}">{% if ip[5] == 1 %}listed{% elif ip[5] == 0 %}clean{% else %}-{% endif %}</td>
                     <td>{{ dnsbl_map[ip[0]]|join(', ') }}</td>
                     <td>{{ 'yes' if ip[4] else 'no' }}</td>
@@ -33,12 +33,13 @@
         <h3 onclick="toggle('g0')" class="group-header">Ungrouped</h3>
         <div id="g0" data-collapse>
         <table>
-            <tr><th><input type="checkbox" onclick="toggleAll(this)"></th><th>IP</th><th>Last Checked</th><th>Status</th><th>DNSBL</th><th>Check Excluded</th></tr>
+            <tr><th><input type="checkbox" onclick="toggleAll(this)"></th><th>IP</th><th>Last Checked</th><th>Next Run</th><th>Status</th><th>DNSBL</th><th>Check Excluded</th></tr>
             {% for ip in ungroup %}
             <tr class="{% if ip[4] %}row-excluded{% elif ip[5] == 1 %}row-listed{% elif ip[5] == 0 %}row-clean{% else %}row-unknown{% endif %}">
                 <td><input type="checkbox" name="ip_id" value="{{ ip[0] }}"></td>
                 <td>{{ ip[1] }}</td>
                 <td>{{ ip[2] or 'never' }}</td>
+                    <td>{{ next_runs[ip[0]] }}</td>
                 <td class="{% if ip[5] == 1 %}status-listed{% elif ip[5] == 0 %}status-clean{% endif %}">{% if ip[5] == 1 %}listed{% elif ip[5] == 0 %}clean{% else %}-{% endif %}</td>
                 <td>{{ dnsbl_map[ip[0]]|join(', ') }}</td>
                 <td>{{ 'yes' if ip[4] else 'no' }}</td>

--- a/blacklist_monitor/templates/schedule.html
+++ b/blacklist_monitor/templates/schedule.html
@@ -1,13 +1,4 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1>Schedule</h1>
-<p>Current schedule: {{ hours }} hours {{ minutes }} minutes</p>
-<form method="post">
-    <label>Hours:</label>
-    <input type="number" name="hours" value="{{ hours }}" min="0" class="telegram-input">
-    <label>Minutes:</label>
-    <input type="number" name="minutes" value="{{ minutes }}" min="0" max="59" class="telegram-input">
-    <input type="submit" value="Update">
-</form>
-<p>Next run: {{ next_run and next_run.strftime('%H:%M') }}</p>
+{% include '_schedule_form.html' %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow multiple schedules per group with new `check_schedules` table
- compute next run per IP group in dashboard
- update dashboard table to show next run for each IP
- convert schedule page to table-based editor with update/delete options

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686b7eb328c08321beb851e920b7b520