### PR TITLE
Improve dashboard and nav labels

### DIFF
--- a/blacklist_monitor/app.py
+++ b/blacklist_monitor/app.py
@@ -191,8 +191,10 @@ def index():
     for ip in ips:
         t = group_next.get(ip[3])
         next_run_map[ip[0]] = t.strftime('%H:%M') if t else ''
+    group_next_map = {gid: t.strftime('%H:%M') for gid, t in group_next.items() if t}
     return render_template('index.html', ips=ips, ip_count=ip_count,
-                           groups=groups, dnsbl_map=dnsbl_map, next_runs=next_run_map)
+                           groups=groups, dnsbl_map=dnsbl_map, next_runs=next_run_map,
+                           group_next=group_next_map)
 
 @app.route('/ips', methods=['GET', 'POST'])
 def manage_ips():

--- a/blacklist_monitor/templates/_schedule_form.html
+++ b/blacklist_monitor/templates/_schedule_form.html
@@ -1,4 +1,4 @@
-<h1>Schedule</h2>
+<h1>Blacklist Check</h1>
 <form method="post" id="schedule-form">
     <input type="hidden" name="action" value="schedule_add">
     {% if edit_schedule %}

--- a/blacklist_monitor/templates/base.html
+++ b/blacklist_monitor/templates/base.html
@@ -8,13 +8,13 @@
 <body>
 <div class="container">
     <div class="sidebar">
-        <h2>Monitor</h2>
+        <h2>Blacklist</h2>
         <ul>
             <li><a href="{{ url_for('index') }}">Dashboard</a></li>
             <li><a href="{{ url_for('manage_ips') }}">IPs</a></li>
             <li><a href="{{ url_for('manage_dnsbls') }}">DNSBLs</a></li>
             <li><a href="{{ url_for('manage_groups') }}">Groups</a></li>
-            <li><a href="{{ url_for('schedule_view') }}">Schedule</a></li>
+            <li><a href="{{ url_for('schedule_view') }}">Blacklist Check</a></li>
             <li><a href="{{ url_for('telegram_settings') }}">Telegram</a></li>
             <li><a href="{{ url_for('backups_view') }}">Backups</a></li>
         </ul>

--- a/blacklist_monitor/templates/index.html
+++ b/blacklist_monitor/templates/index.html
@@ -7,7 +7,7 @@
     <button type="submit" formaction="{{ url_for('exclude_selected') }}">Exclude Selected</button>
     <button type="submit" formaction="{{ url_for('include_selected') }}">Include Selected</button>
     {% for g in groups %}
-        <h3 onclick="toggle('g{{ g[0] }}')" class="group-header">{{ g[1] }}</h3>
+        <h3 onclick="toggle('g{{ g[0] }}')" class="group-header">{{ g[1] }}{% if group_next.get(g[0]) %} - {{ group_next[g[0]] }}{% endif %}</h3>
         <div id="g{{ g[0] }}" data-collapse>
         <table>
             <tr><th><input type="checkbox" onclick="toggleAll(this)"></th><th>IP</th><th>Last Checked</th><th>Next Run</th><th>Status</th><th>DNSBL</th><th>Check Excluded</th></tr>
@@ -30,7 +30,7 @@
     {% set ungroup = [] %}
     {% for ip in ips %}{% if not ip[3] %}{% set _ = ungroup.append(ip) %}{% endif %}{% endfor %}
     {% if ungroup %}
-        <h3 onclick="toggle('g0')" class="group-header">Ungrouped</h3>
+        <h3 onclick="toggle('g0')" class="group-header">Ungrouped{% if group_next.get(None) %} - {{ group_next[None] }}{% endif %}</h3>
         <div id="g0" data-collapse>
         <table>
             <tr><th><input type="checkbox" onclick="toggleAll(this)"></th><th>IP</th><th>Last Checked</th><th>Next Run</th><th>Status</th><th>DNSBL</th><th>Check Excluded</th></tr>


### PR DESCRIPTION
## Summary
- display each group's next check time on the dashboard
- rename sidebar title to **Blacklist**
- rename schedule navigation to **Blacklist Check**
- update schedule page heading accordingly

## Testing
- `python -m py_compile blacklist_monitor/app.py`


------
https://chatgpt.com/codex/tasks/task_e_686b8702d8188321bcdacd8da034f519