### PR TITLE
UI scheduling fixes

### DIFF
--- a/blacklist_monitor/templates/_schedule_form.html
+++ b/blacklist_monitor/templates/_schedule_form.html
@@ -1,4 +1,4 @@
-<h1>Blacklist Check</h1>
+<h1>Schedule</h1>
 <form method="post" id="schedule-form">
     <input type="hidden" name="action" value="schedule_add">
     {% if edit_schedule %}

--- a/blacklist_monitor/templates/base.html
+++ b/blacklist_monitor/templates/base.html
@@ -14,7 +14,7 @@
             <li><a href="{{ url_for('manage_ips') }}">IPs</a></li>
             <li><a href="{{ url_for('manage_dnsbls') }}">DNSBLs</a></li>
             <li><a href="{{ url_for('manage_groups') }}">Groups</a></li>
-            <li><a href="{{ url_for('schedule_view') }}">Blacklist Check</a></li>
+            <li><a href="{{ url_for('schedule_view') }}">Schedule</a></li>
             <li><a href="{{ url_for('telegram_settings') }}">Telegram</a></li>
             <li><a href="{{ url_for('backups_view') }}">Backups</a></li>
         </ul>

--- a/blacklist_monitor/templates/index.html
+++ b/blacklist_monitor/templates/index.html
@@ -10,14 +10,13 @@
         <h3 onclick="toggle('g{{ g[0] }}')" class="group-header">{{ g[1] }}{% if group_next.get(g[0]) %} - {{ group_next[g[0]] }}{% endif %}</h3>
         <div id="g{{ g[0] }}" data-collapse>
         <table>
-            <tr><th><input type="checkbox" onclick="toggleAll(this)"></th><th>IP</th><th>Last Checked</th><th>Next Run</th><th>Status</th><th>DNSBL</th><th>Check Excluded</th></tr>
+            <tr><th><input type="checkbox" onclick="toggleAll(this)"></th><th>IP</th><th>Last Checked</th><th>Status</th><th>DNSBL</th><th>Check Excluded</th></tr>
             {% for ip in ips %}
                 {% if ip[3] == g[0] %}
                 <tr class="{% if ip[4] %}row-excluded{% elif ip[5] == 1 %}row-listed{% elif ip[5] == 0 %}row-clean{% else %}row-unknown{% endif %}">
                     <td><input type="checkbox" name="ip_id" value="{{ ip[0] }}"></td>
                     <td>{{ ip[1] }}</td>
                     <td>{{ ip[2] or 'never' }}</td>
-                    <td>{{ next_runs[ip[0]] }}</td>
                     <td class="{% if ip[5] == 1 %}status-listed{% elif ip[5] == 0 %}status-clean{% endif %}">{% if ip[5] == 1 %}listed{% elif ip[5] == 0 %}clean{% else %}-{% endif %}</td>
                     <td>{{ dnsbl_map[ip[0]]|join(', ') }}</td>
                     <td>{{ 'yes' if ip[4] else 'no' }}</td>
@@ -33,13 +32,12 @@
         <h3 onclick="toggle('g0')" class="group-header">Ungrouped{% if group_next.get(None) %} - {{ group_next[None] }}{% endif %}</h3>
         <div id="g0" data-collapse>
         <table>
-            <tr><th><input type="checkbox" onclick="toggleAll(this)"></th><th>IP</th><th>Last Checked</th><th>Next Run</th><th>Status</th><th>DNSBL</th><th>Check Excluded</th></tr>
+            <tr><th><input type="checkbox" onclick="toggleAll(this)"></th><th>IP</th><th>Last Checked</th><th>Status</th><th>DNSBL</th><th>Check Excluded</th></tr>
             {% for ip in ungroup %}
             <tr class="{% if ip[4] %}row-excluded{% elif ip[5] == 1 %}row-listed{% elif ip[5] == 0 %}row-clean{% else %}row-unknown{% endif %}">
                 <td><input type="checkbox" name="ip_id" value="{{ ip[0] }}"></td>
                 <td>{{ ip[1] }}</td>
                 <td>{{ ip[2] or 'never' }}</td>
-                    <td>{{ next_runs[ip[0]] }}</td>
                 <td class="{% if ip[5] == 1 %}status-listed{% elif ip[5] == 0 %}status-clean{% endif %}">{% if ip[5] == 1 %}listed{% elif ip[5] == 0 %}clean{% else %}-{% endif %}</td>
                 <td>{{ dnsbl_map[ip[0]]|join(', ') }}</td>
                 <td>{{ 'yes' if ip[4] else 'no' }}</td>


### PR DESCRIPTION
## Summary
- remove Next Run column from dashboard tables
- show group next run times near group names using the `dd/mm/yyyy hh:mm am/pm` format
- rename navigation link and heading from "Blacklist Check" to "Schedule"
- default backup retention days to 0

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b8b13456883218b98c8c05d6da8bf