### PR TITLE
Add realtime log viewer

### DIFF
--- a/blacklist_monitor/README.md
+++ b/blacklist_monitor/README.md
@@ -48,3 +48,18 @@ docker run -p 5000:5000 \
 ```
 
 The web interface will then be available at `http://localhost:5000`.
+
+## Logs
+
+The sidebar includes a **Logs** page that streams recent application output.
+This allows you to watch requests in real time without accessing the console.
+
+Example output:
+
+```
+124.217.240.99 - - [07/Jul/2025 17:14:03] "GET /ips HTTP/1.1" 200 -
+124.217.240.99 - - [07/Jul/2025 17:14:03] "GET /static/style.css HTTP/1.1" 304 -
+124.217.240.99 - - [07/Jul/2025 17:14:03] "GET /static/script.js HTTP/1.1" 304 -
+124.217.240.99 - - [07/Jul/2025 17:14:04] "GET / HTTP/1.1" 200 -
+```
+

--- a/blacklist_monitor/static/script.js
+++ b/blacklist_monitor/static/script.js
@@ -98,4 +98,18 @@ window.addEventListener('load', function() {
       localStorage.setItem(key, this.value);
     });
   });
+
+  if (document.getElementById('log-output')) {
+    function fetchLogs() {
+      fetch('/log_feed').then(function(r) { return r.text(); }).then(function(t) {
+        const pre = document.getElementById('log-output');
+        if (pre) {
+          pre.textContent = t;
+          pre.scrollTop = pre.scrollHeight;
+        }
+      });
+    }
+    fetchLogs();
+    setInterval(fetchLogs, 2000);
+  }
 });

--- a/blacklist_monitor/static/style.css
+++ b/blacklist_monitor/static/style.css
@@ -151,3 +151,12 @@ button, input[type="submit"] {
 #search-section {
     margin-top: 2em;
 }
+
+.log-output {
+    background: #000;
+    color: #0f0;
+    padding: 1em;
+    height: 300px;
+    overflow-y: scroll;
+    font-family: monospace;
+}

--- a/blacklist_monitor/templates/base.html
+++ b/blacklist_monitor/templates/base.html
@@ -17,6 +17,7 @@
             <li><a href="{{ url_for('schedule_view') }}">Schedule</a></li>
             <li><a href="{{ url_for('telegram_settings') }}">Telegram</a></li>
             <li><a href="{{ url_for('backups_view') }}">Backups</a></li>
+            <li><a href="{{ url_for('view_logs') }}">Logs</a></li>
         </ul>
     </div>
     <div class="content">

--- a/blacklist_monitor/templates/logs.html
+++ b/blacklist_monitor/templates/logs.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Logs</h1>
+<pre id="log-output" class="log-output"></pre>
+{% endblock %}


### PR DESCRIPTION
## Summary
- provide in-memory log capture and new /logs route
- add Logs link to navigation and basic template
- poll /log_feed from the browser to show logs live
- style log output in CSS
- document new log viewer feature

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686b905376388321be9c842300eb806a