### PR TITLE
Move log history setting

### DIFF
--- a/blacklist_monitor/README.md
+++ b/blacklist_monitor/README.md
@@ -53,6 +53,7 @@ The web interface will then be available at `http://localhost:5000`.
 
 The sidebar includes a **Logs** page that streams recent application output.
 This allows you to watch requests in real time without accessing the console.
+You can configure how many recent entries are kept using the *History size* setting.
 
 Example output:
 

--- a/blacklist_monitor/static/style.css
+++ b/blacklist_monitor/static/style.css
@@ -160,3 +160,6 @@ button, input[type="submit"] {
     overflow-y: scroll;
     font-family: monospace;
 }
+.log-settings {
+    margin-bottom: 1em;
+}

--- a/blacklist_monitor/templates/logs.html
+++ b/blacklist_monitor/templates/logs.html
@@ -1,5 +1,10 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Logs</h1>
+<form method="post" class="log-settings">
+    <label>History size:</label>
+    <input type="number" name="history_size" value="{{ history_size }}" min="1" class="telegram-input">
+    <input type="submit" value="Save">
+</form>
 <pre id="log-output" class="log-output"></pre>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add new LOG_HISTORY_SIZE setting and use it in the log viewer
- allow adjusting the log history limit from the Logs page
- document the new option in the README

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b9779704883218831fa0624970bc5