### PR TITLE
Add remark column and telegram support

### DIFF
--- a/blacklist_monitor/static/style.css
+++ b/blacklist_monitor/static/style.css
@@ -89,6 +89,10 @@ button, input[type="submit"] {
     margin: 0.2em 0;
     width: 300px;
 }
+.remark-input {
+    width: 220px;
+    padding: 0.2em;
+}
 .row-listed { background-color: #ffe6e6; }
 .row-clean { background-color: #e6ffe6; }
 .row-unknown { background-color: #f9f9f9; }

--- a/blacklist_monitor/templates/index.html
+++ b/blacklist_monitor/templates/index.html
@@ -7,16 +7,18 @@
     <button type="submit">Check Selected</button>
     <button type="submit" formaction="{{ url_for('exclude_selected') }}">Exclude Selected</button>
     <button type="submit" formaction="{{ url_for('include_selected') }}">Include Selected</button>
+    <button type="submit" formaction="{{ url_for('update_selected') }}">Update Selected</button>
     {% for g in groups %}
         <h3 onclick="toggle('g{{ g[0] }}')" class="group-header">{{ g[1] }}{% if group_next.get(g[0]) %} - {{ group_next[g[0]] }}{% endif %}</h3>
         <div id="g{{ g[0] }}" data-collapse>
         <table>
-            <tr><th><input type="checkbox" onclick="toggleAll(this)"></th><th>IP</th><th>Last Checked</th><th>Status</th><th>DNSBL</th><th>Check Excluded</th></tr>
+            <tr><th><input type="checkbox" onclick="toggleAll(this)"></th><th>IP</th><th>Remark</th><th>Last Checked</th><th>Status</th><th>DNSBL</th><th>Check Excluded</th></tr>
             {% for ip in ips %}
                 {% if ip[3] == g[0] %}
                 <tr class="{% if ip[4] %}row-excluded{% elif ip[5] == 1 %}row-listed{% elif ip[5] == 0 %}row-clean{% else %}row-unknown{% endif %}">
                     <td><input type="checkbox" name="ip_id" value="{{ ip[0] }}"></td>
                     <td>{{ ip[1] }}</td>
+                    <td><input type="text" name="remark_{{ ip[0] }}" value="{{ ip[6] }}" class="remark-input"></td>
                     <td>{{ ip[2] or 'never' }}</td>
                     <td class="{% if ip[5] == 1 %}status-listed{% elif ip[5] == 0 %}status-clean{% endif %}">{% if ip[5] == 1 %}listed{% elif ip[5] == 0 %}clean{% else %}-{% endif %}</td>
                     <td>{{ dnsbl_map[ip[0]]|join(', ') }}</td>
@@ -33,11 +35,12 @@
         <h3 onclick="toggle('g0')" class="group-header">Ungrouped{% if group_next.get(None) %} - {{ group_next[None] }}{% endif %}</h3>
         <div id="g0" data-collapse>
         <table>
-            <tr><th><input type="checkbox" onclick="toggleAll(this)"></th><th>IP</th><th>Last Checked</th><th>Status</th><th>DNSBL</th><th>Check Excluded</th></tr>
+            <tr><th><input type="checkbox" onclick="toggleAll(this)"></th><th>IP</th><th>Remark</th><th>Last Checked</th><th>Status</th><th>DNSBL</th><th>Check Excluded</th></tr>
             {% for ip in ungroup %}
             <tr class="{% if ip[4] %}row-excluded{% elif ip[5] == 1 %}row-listed{% elif ip[5] == 0 %}row-clean{% else %}row-unknown{% endif %}">
                 <td><input type="checkbox" name="ip_id" value="{{ ip[0] }}"></td>
                 <td>{{ ip[1] }}</td>
+                <td><input type="text" name="remark_{{ ip[0] }}" value="{{ ip[6] }}" class="remark-input"></td>
                 <td>{{ ip[2] or 'never' }}</td>
                 <td class="{% if ip[5] == 1 %}status-listed{% elif ip[5] == 0 %}status-clean{% endif %}">{% if ip[5] == 1 %}listed{% elif ip[5] == 0 %}clean{% else %}-{% endif %}</td>
                 <td>{{ dnsbl_map[ip[0]]|join(', ') }}</td>


### PR DESCRIPTION
## Summary
- add remark column to IP database table
- allow editing remarks on dashboard
- add Update Selected action
- include remark in Telegram alerts
- style remark input field

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686cb6c60f208321a47699cd31ff45ca