### PR TITLE
Add features overview page and Telegram help

### DIFF
--- a/blacklist_monitor/app.py
+++ b/blacklist_monitor/app.py
@@ -225,6 +225,12 @@ def index():
                            groups=groups, dnsbl_map=dnsbl_map,
                            group_next=group_next_map)
 
+
+@app.route('/features')
+def features_page():
+    """Display an overview of the application's capabilities."""
+    return render_template('features.html')
+
 @app.route('/ips', methods=['GET', 'POST'])
 def manage_ips():
     with sqlite3.connect(DB_PATH, timeout=DB_TIMEOUT) as conn:

--- a/blacklist_monitor/static/style.css
+++ b/blacklist_monitor/static/style.css
@@ -21,6 +21,13 @@ body {
     color: #fff;
     margin-top: 0;
 }
+.sidebar h2 a {
+    color: inherit;
+    text-decoration: none;
+}
+.sidebar h2 a:hover {
+    text-decoration: underline;
+}
 
 .sidebar ul {
     list-style: none;
@@ -83,6 +90,9 @@ button, input[type="submit"] {
     width: 80px;
     border: 1px solid #ccc;
     border-radius: 4px;
+}
+.placeholder-help {
+    margin-top: 0.5em;
 }
 .wide-select {
     padding: 0.4em;

--- a/blacklist_monitor/templates/base.html
+++ b/blacklist_monitor/templates/base.html
@@ -8,7 +8,7 @@
 <body>
 <div class="container">
     <div class="sidebar">
-        <h2>Blacklist</h2>
+        <h2><a href="{{ url_for('features_page') }}">Blacklist</a></h2>
         <ul>
             <li><a href="{{ url_for('index') }}">Dashboard</a></li>
             <li><a href="{{ url_for('manage_ips') }}">IPs</a></li>

--- a/blacklist_monitor/templates/features.html
+++ b/blacklist_monitor/templates/features.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Application Features</h1>
+<p>This page provides an overview of what the blacklist monitor can do.</p>
+<ul>
+    <li>Add or remove single IPs or CIDR ranges.</li>
+    <li>Add or remove DNSBL domains (bulk import supported).</li>
+    <li>Create groups and assign IPs using checkboxes.</li>
+    <li>Manual blacklist check for a single IP.</li>
+    <li>Adjustable check schedule via the web UI.</li>
+    <li>Periodic checks run according to the configured schedule.</li>
+    <li>Alerts are sent to a Telegram chat when an IP is blacklisted.</li>
+    <li>Dashboard shows last and next check times along with blacklist results.</li>
+    <li>Backup past check results with searchable history and configurable schedule.</li>
+</ul>
+{% endblock %}

--- a/blacklist_monitor/templates/telegram.html
+++ b/blacklist_monitor/templates/telegram.html
@@ -18,6 +18,7 @@
     <button type="submit">Add</button>
 </form>
 <p>Available placeholders: <code>{ip}</code>, <code>{dnsbl}</code>, <code>{remark}</code>, <code>{date}</code>, <code>{time}</code>, <code>{count}</code></p>
+<p class="placeholder-help">Use these tags inside the alert message to insert the IP address, DNSBL name, your remark, the current date and time, or the number of listings.</p>
 
 <h2>Saved Chats</h2>
 <form method="post">


### PR DESCRIPTION
## Summary
- make side-pane title clickable
- show features overview page when clicking "Blacklist" title
- document Telegram placeholders in detail

## Testing
- `python -m py_compile blacklist_monitor/app.py`

------
https://chatgpt.com/codex/tasks/task_e_686cc36d15c88321905fd7e909a02e67