### PR TITLE
UI dropdown tweaks and ping check

### DIFF
--- a/blacklist_monitor/static/script.js
+++ b/blacklist_monitor/static/script.js
@@ -175,4 +175,23 @@ window.addEventListener('load', function() {
     });
     updateText();
   });
+
+  document.querySelectorAll('.dropdown-details').forEach(function(dd) {
+    var summary = dd.querySelector('summary');
+    function updateText() {
+      var checked = dd.querySelectorAll('input[type="checkbox"]:checked');
+      if (checked.length === 0) {
+        summary.textContent = 'Select';
+      } else if (checked.length === 1) {
+        summary.textContent = checked[0].parentNode.textContent.trim();
+      } else {
+        summary.textContent = checked.length + ' selected';
+      }
+    }
+    dd.addEventListener('toggle', updateText);
+    dd.querySelectorAll('input[type="checkbox"]').forEach(function(cb) {
+      cb.addEventListener('change', updateText);
+    });
+    updateText();
+  });
 });

--- a/blacklist_monitor/static/style.css
+++ b/blacklist_monitor/static/style.css
@@ -213,3 +213,31 @@ button, input[type="submit"] {
     overflow-y: auto;
     z-index: 10;
 }
+
+.dropdown-details {
+    position: relative;
+    display: inline-block;
+}
+
+.dropdown-details summary {
+    padding: 0.4em;
+    width: 150px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    cursor: pointer;
+    list-style: none;
+}
+
+.dropdown-details div {
+    position: absolute;
+    background: #fff;
+    border: 1px solid #ccc;
+    padding: 0.4em;
+    max-height: 200px;
+    overflow-y: auto;
+    z-index: 10;
+}
+
+.type-label {
+    margin-right: 0.8em;
+}

--- a/blacklist_monitor/templates/_schedule_form.html
+++ b/blacklist_monitor/templates/_schedule_form.html
@@ -13,21 +13,21 @@
         {% endfor %}
     </select>
     {% else %}
-    <div class="checkbox-dropdown">
-        <button type="button">Select Groups</button>
-        <div class="checkbox-dropdown-menu">
+    <details class="dropdown-details">
+        <summary>Select Groups</summary>
+        <div>
             <label><input type="checkbox" name="group_ids" value=""> All Groups</label><br>
             {% for g in groups %}
             <label><input type="checkbox" name="group_ids" value="{{ g[0] }}"> {{ g[1] }}</label><br>
             {% endfor %}
         </div>
-    </div>
+    </details>
     {% endif %}
     <input type="hidden" name="type" id="schedule-type" value="{{ edit_schedule.type if edit_schedule else 'daily' }}">
-    <label><input type="checkbox" id="schedule-daily" onclick="selectType('schedule','daily')" {% if not edit_schedule or edit_schedule.type=='daily' %}checked{% endif %}>Daily</label>
-    <label><input type="checkbox" id="schedule-weekly" onclick="selectType('schedule','weekly')" {% if edit_schedule and edit_schedule.type=='weekly' %}checked{% endif %}>Weekly</label>
-    <label><input type="checkbox" id="schedule-monthly" onclick="selectType('schedule','monthly')" {% if edit_schedule and edit_schedule.type=='monthly' %}checked{% endif %}>Monthly</label>
-    <label><input type="checkbox" id="schedule-hourly" onclick="selectType('schedule','hourly')" {% if edit_schedule and edit_schedule.type=='hourly' %}checked{% endif %}>Hourly</label>
+    <label class="type-label"><input type="checkbox" id="schedule-daily" onclick="selectType('schedule','daily')" {% if not edit_schedule or edit_schedule.type=='daily' %}checked{% endif %}>Daily</label>
+    <label class="type-label"><input type="checkbox" id="schedule-weekly" onclick="selectType('schedule','weekly')" {% if edit_schedule and edit_schedule.type=='weekly' %}checked{% endif %}>Weekly</label>
+    <label class="type-label"><input type="checkbox" id="schedule-monthly" onclick="selectType('schedule','monthly')" {% if edit_schedule and edit_schedule.type=='monthly' %}checked{% endif %}>Monthly</label>
+    <label class="type-label"><input type="checkbox" id="schedule-hourly" onclick="selectType('schedule','hourly')" {% if edit_schedule and edit_schedule.type=='hourly' %}checked{% endif %}>Hourly</label>
     <span id="schedule-day-weekly">
         <select name="day" class="day-select">
             <option value="mon" {% if edit_schedule and edit_schedule.type=='weekly' and edit_schedule.day=='mon' %}selected{% endif %}>Mon</option>
@@ -69,19 +69,22 @@
         <tr class="schedule-row" data-row-id="{{ s.id }}">
             <td><input type="checkbox" name="schedule_id" value="{{ s.id }}"></td>
             <td>
-                <select name="group_id_{{ s.id }}" class="short-select">
-                    <option value="">All Groups</option>
-                    {% for g in groups %}
-                    <option value="{{ g[0] }}" {% if s.group_id==g[0] %}selected{% endif %}>{{ g[1] }}</option>
-                    {% endfor %}
-                </select>
+                <details class="dropdown-details">
+                    <summary>Select Groups</summary>
+                    <div>
+                        <label><input type="checkbox" name="group_id_{{ s.id }}" value="" {% if not s.group_id %}checked{% endif %}> All Groups</label><br>
+                        {% for g in groups %}
+                        <label><input type="checkbox" name="group_id_{{ s.id }}" value="{{ g[0] }}" {% if s.group_id==g[0] %}checked{% endif %}> {{ g[1] }}</label><br>
+                        {% endfor %}
+                    </div>
+                </details>
             </td>
             <td>
                 <input type="hidden" name="type_{{ s.id }}" id="row-{{ s.id }}-type" value="{{ s.type }}">
-                <label><input type="checkbox" id="row-{{ s.id }}-daily" onclick="selectType('row-{{ s.id }}','daily')" {% if s.type=='daily' %}checked{% endif %}>Daily</label>
-                <label><input type="checkbox" id="row-{{ s.id }}-weekly" onclick="selectType('row-{{ s.id }}','weekly')" {% if s.type=='weekly' %}checked{% endif %}>Weekly</label>
-                <label><input type="checkbox" id="row-{{ s.id }}-monthly" onclick="selectType('row-{{ s.id }}','monthly')" {% if s.type=='monthly' %}checked{% endif %}>Monthly</label>
-                <label><input type="checkbox" id="row-{{ s.id }}-hourly" onclick="selectType('row-{{ s.id }}','hourly')" {% if s.type=='hourly' %}checked{% endif %}>Hourly</label>
+                <label class="type-label"><input type="checkbox" id="row-{{ s.id }}-daily" onclick="selectType('row-{{ s.id }}','daily')" {% if s.type=='daily' %}checked{% endif %}>Daily</label>
+                <label class="type-label"><input type="checkbox" id="row-{{ s.id }}-weekly" onclick="selectType('row-{{ s.id }}','weekly')" {% if s.type=='weekly' %}checked{% endif %}>Weekly</label>
+                <label class="type-label"><input type="checkbox" id="row-{{ s.id }}-monthly" onclick="selectType('row-{{ s.id }}','monthly')" {% if s.type=='monthly' %}checked{% endif %}>Monthly</label>
+                <label class="type-label"><input type="checkbox" id="row-{{ s.id }}-hourly" onclick="selectType('row-{{ s.id }}','hourly')" {% if s.type=='hourly' %}checked{% endif %}>Hourly</label>
             </td>
             <td>
                 <span id="row-{{ s.id }}-day-weekly">

--- a/blacklist_monitor/templates/dnsbls.html
+++ b/blacklist_monitor/templates/dnsbls.html
@@ -11,6 +11,7 @@
     <br>
     <button type="submit" formaction="{{ url_for('bulk_dnsbls') }}">Add List</button>
     <button type="submit" formaction="{{ url_for('delete_selected_dnsbls') }}">Delete Selected</button>
+    <button type="submit" formaction="{{ url_for('ping_selected_dnsbls') }}">Ping Test</button>
     <br><br>
     <table>
         <tr><th><input type="checkbox" onclick="toggleAll(this)"></th><th>DNSBL</th></tr>

--- a/blacklist_monitor/templates/groups.html
+++ b/blacklist_monitor/templates/groups.html
@@ -3,14 +3,14 @@
 <h1>Groups</h1>
 <form method="post" class="action-buttons">
     <input type="text" name="group" placeholder="Group name" required class="telegram-input">
-    <div class="checkbox-dropdown">
-        <button type="button">Select Chats</button>
-        <div class="checkbox-dropdown-menu">
+    <details class="dropdown-details">
+        <summary>Select Chats</summary>
+        <div>
             {% for c in chats %}
             <label><input type="checkbox" name="add_chats" value="{{ c[0] }}"> {{ c[1] }}</label><br>
             {% endfor %}
         </div>
-    </div>
+    </details>
     <input type="submit" value="Add">
 </form>
 
@@ -30,14 +30,14 @@
             <td><input type="checkbox" name="group_id" value="{{ g[0] }}"></td>
             <td><input type="text" name="group_name_{{ g[0] }}" value="{{ g[1] }}" class="telegram-input"></td>
             <td>
-                <div class="checkbox-dropdown">
-                    <button type="button">Select Chats</button>
-                    <div class="checkbox-dropdown-menu">
+                <details class="dropdown-details">
+                    <summary>Select Chats</summary>
+                    <div>
                         {% for c in chats %}
                         <label><input type="checkbox" name="chats_{{ g[0] }}" value="{{ c[0] }}" {% if c[0] in group_chats.get(g[0], []) %}checked{% endif %}> {{ c[1] }}</label><br>
                         {% endfor %}
                     </div>
-                </div>
+                </details>
             </td>
         </tr>
         {% endfor %}

--- a/blacklist_monitor/templates/ping_results.html
+++ b/blacklist_monitor/templates/ping_results.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Ping Results</h1>
+<table>
+<tr><th>Domain</th><th>Reachable</th></tr>
+{% for d, ok in results %}
+<tr><td>{{ d }}</td><td>{{ 'OK' if ok else 'Fail' }}</td></tr>
+{% endfor %}
+</table>
+<a href="{{ url_for('manage_dnsbls') }}">Back</a>
+{% endblock %}

--- a/blacklist_monitor/templates/telegram.html
+++ b/blacklist_monitor/templates/telegram.html
@@ -12,9 +12,8 @@
     <input type="text" name="chat_name" class="telegram-input name-input">
     <label><input type="checkbox" name="active" checked> Active</label>
     <input type="text" name="alert_message" value="{{ message }}" class="telegram-input">
-    <label>Resend per</label>
-    <input type="number" name="resend_hours" value="{{ resend_hours }}" min="0" class="telegram-time-input" placeholder="hours">
-    <input type="number" name="resend_minutes" value="{{ resend_minutes }}" min="0" max="59" class="telegram-time-input" placeholder="minutes">
+    <label>Resend Times:</label>
+    <input type="number" name="resend_times" value="{{ resend_times }}" min="0" class="telegram-time-input">
     <br>
     <button type="submit">Add</button>
 </form>
@@ -39,8 +38,7 @@
                 <th>Chat ID</th>
                 <th>Active</th>
                 <th>Alert Message</th>
-                <th>Hours</th>
-                <th>Minutes</th>
+                <th>Times</th>
             </tr>
         </thead>
         <tbody>
@@ -52,8 +50,7 @@
                 <td><input type="text" name="chatid_{{ c[0] }}" value="{{ c[2] }}" class="telegram-input chatid-input"></td>
                 <td><input type="checkbox" name="active_{{ c[0] }}" {% if c[4] %}checked{% endif %}></td>
                 <td><input type="text" name="alert_message_{{ c[0] }}" value="{{ c[5] }}" placeholder="{{ message }}" class="telegram-input"></td>
-                <td><input type="number" name="resend_hours_{{ c[0] }}" value="{{ c[6] }}" min="0" class="telegram-time-input"></td>
-                <td><input type="number" name="resend_minutes_{{ c[0] }}" value="{{ c[7] }}" min="0" max="59" class="telegram-time-input"></td>
+                <td><input type="number" name="resend_times_{{ c[0] }}" value="{{ c[6] }}" min="0" class="telegram-time-input"></td>
             </tr>
         {% endfor %}
         </tbody>


### PR DESCRIPTION
## Summary
- switch group and schedule chat selections to details dropdowns
- convert telegram resend fields to a single times value
- add ping test for DNSBL entries
- update styles and scripts for new dropdown behavior

## Testing
- `python -m py_compile blacklist_monitor/app.py`

------
https://chatgpt.com/codex/tasks/task_e_686cee424540832192dcab96cb3cfbb4