### PR TITLE
UI tweaks and ping improvements

### DIFF
--- a/blacklist_monitor/static/script.js
+++ b/blacklist_monitor/static/script.js
@@ -36,6 +36,7 @@ function updateScheduleDisplay(prefix) {
   const weeklyWrap = document.getElementById(prefix + '-day-weekly');
   const monthlyWrap = document.getElementById(prefix + '-day-monthly');
   const ampmSel = document.getElementById(prefix + '-ampm');
+  const timeLabel = document.getElementById(prefix + '-time-label');
 
   if (hidden) {
     if (hourly && hourly.checked) hidden.value = 'hourly';
@@ -67,6 +68,14 @@ function updateScheduleDisplay(prefix) {
     const show = !(hourly && hourly.checked);
     ampmSel.style.display = show ? '' : 'none';
     ampmSel.disabled = !show;
+  }
+
+  if (timeLabel) {
+    if (hourly && hourly.checked) {
+      timeLabel.textContent = 'Per';
+    } else {
+      timeLabel.textContent = 'Time:';
+    }
   }
 }
 
@@ -118,6 +127,7 @@ window.addEventListener('load', function() {
   });
 
   if (document.getElementById('log-output')) {
+    let logTimer;
     function fetchLogs() {
       fetch('/log_feed').then(function(r) { return r.text(); }).then(function(t) {
         const pre = document.getElementById('log-output');
@@ -134,8 +144,29 @@ window.addEventListener('load', function() {
         }
       });
     }
-    fetchLogs();
-    setInterval(fetchLogs, 2000);
+    function startLogs() {
+      fetchLogs();
+      logTimer = setInterval(fetchLogs, 2000);
+    }
+    function stopLogs() {
+      if (logTimer) {
+        clearInterval(logTimer);
+        logTimer = null;
+      }
+    }
+    const toggle = document.getElementById('log-toggle');
+    if (toggle) {
+      toggle.addEventListener('click', function() {
+        if (logTimer) {
+          stopLogs();
+          this.textContent = 'Resume';
+        } else {
+          startLogs();
+          this.textContent = 'Stop';
+        }
+      });
+    }
+    startLogs();
   }
 
   if (document.getElementById('system-stats')) {
@@ -160,10 +191,11 @@ window.addEventListener('load', function() {
       var checked = menu.querySelectorAll('input[type="checkbox"]:checked');
       if (checked.length === 0) {
         btn.textContent = 'Select';
-      } else if (checked.length === 1) {
-        btn.textContent = checked[0].parentNode.textContent.trim();
       } else {
-        btn.textContent = checked.length + ' selected';
+        var names = Array.from(checked).map(function(cb){
+          return cb.parentNode.textContent.trim();
+        });
+        btn.textContent = names.join(', ');
       }
     }
     btn.addEventListener('click', function(e) {
@@ -182,10 +214,11 @@ window.addEventListener('load', function() {
       var checked = dd.querySelectorAll('input[type="checkbox"]:checked');
       if (checked.length === 0) {
         summary.textContent = 'Select';
-      } else if (checked.length === 1) {
-        summary.textContent = checked[0].parentNode.textContent.trim();
       } else {
-        summary.textContent = checked.length + ' selected';
+        var names = Array.from(checked).map(function(cb){
+          return cb.parentNode.textContent.trim();
+        });
+        summary.textContent = names.join(', ');
       }
     }
     dd.addEventListener('toggle', updateText);

--- a/blacklist_monitor/static/style.css
+++ b/blacklist_monitor/static/style.css
@@ -241,3 +241,8 @@ button, input[type="submit"] {
 .type-label {
     margin-right: 0.8em;
 }
+
+.small-note {
+    font-size: 0.9em;
+    color: #555;
+}

--- a/blacklist_monitor/templates/_schedule_form.html
+++ b/blacklist_monitor/templates/_schedule_form.html
@@ -42,7 +42,7 @@
     <span id="schedule-day-monthly">
         <input type="date" name="day" class="telegram-time-input date-input" {% if edit_schedule and edit_schedule.type=='monthly' %}value="{{ edit_schedule.date_value }}"{% endif %}>
     </span>
-    <label>Time:</label>
+    <span id="schedule-time-label" class="time-label">Time:</span>
     <input type="number" name="hour" min="0" max="23" class="telegram-time-input" {% if edit_schedule %}value="{{ edit_schedule.hour }}"{% endif %}>
     <input type="number" name="minute" min="0" max="59" class="telegram-time-input" {% if edit_schedule %}value="{{ edit_schedule.minute }}"{% endif %}>
     <select name="ampm" class="ampm-select" id="schedule-ampm">
@@ -103,6 +103,7 @@
                 </span>
             </td>
             <td>
+                <span id="row-{{ s.id }}-time-label" class="time-label">Time:</span>
                 <input type="number" name="hour_{{ s.id }}" min="0" max="23" class="telegram-time-input" value="{{ s.hour }}">
                 <input type="number" name="minute_{{ s.id }}" min="0" max="59" class="telegram-time-input" value="{{ s.minute }}">
                 <select name="ampm_{{ s.id }}" class="ampm-select" id="row-{{ s.id }}-ampm">

--- a/blacklist_monitor/templates/backups.html
+++ b/blacklist_monitor/templates/backups.html
@@ -122,6 +122,7 @@
     <input type="number" name="count" value="{{ retention_count }}" min="0" class="telegram-input small-number">
     <input type="submit" value="Save">
 </form>
+<p class="small-note">Keep Days removes backups older than the specified days. Keep Count limits the total number of backups.</p>
 <h2>Existing Backups</h2>
 <form method="post">
     <div class="action-buttons">

--- a/blacklist_monitor/templates/logs.html
+++ b/blacklist_monitor/templates/logs.html
@@ -6,5 +6,6 @@
     <input type="number" name="history_size" value="{{ history_size }}" min="1" class="telegram-input">
     <input type="submit" value="Save">
 </form>
+<button type="button" id="log-toggle">Stop</button>
 <pre id="log-output" class="log-output"></pre>
 {% endblock %}

--- a/blacklist_monitor/templates/ping_results.html
+++ b/blacklist_monitor/templates/ping_results.html
@@ -2,9 +2,9 @@
 {% block content %}
 <h1>Ping Results</h1>
 <table>
-<tr><th>Domain</th><th>Reachable</th></tr>
-{% for d, ok in results %}
-<tr><td>{{ d }}</td><td>{{ 'OK' if ok else 'Fail' }}</td></tr>
+<tr><th>Domain</th><th>Reachable</th><th>Latency (ms)</th></tr>
+{% for d, ok, lat in results %}
+<tr><td>{{ d }}</td><td>{{ 'OK' if ok else 'Fail' }}</td><td>{{ lat if lat is not none else 'N/A' }}</td></tr>
 {% endfor %}
 </table>
 <a href="{{ url_for('manage_dnsbls') }}">Back</a>


### PR DESCRIPTION
## Summary
- show ping latency when testing DNSBLs
- show selected group names directly
- add stop/resume button for live logs
- clarify backup retention settings and apply immediately
- fix timezone bug when computing next check time

## Testing
- `python3 -m py_compile blacklist_monitor/app.py`

------
https://chatgpt.com/codex/tasks/task_e_686dd3e7faf48321b767a02ccb33b1ae