### PR TITLE
Improve DNSBL dig doc and backup spacing

### DIFF
--- a/blacklist_monitor/README.md
+++ b/blacklist_monitor/README.md
@@ -13,6 +13,23 @@ Features:
 - Dashboard shows last and next check times along with blacklist results.
 - Backup past check results with searchable history and configurable schedule.
 
+## DNSBLs
+
+The **DNSBLs** page manages the blacklist domains that will be queried.
+Each listed DNSBL supports a **Dig Test** feature to perform ad-hoc lookups.
+You may optionally provide:
+
+* **IP** – reversed before being appended to the DNSBL domain
+* **Server** – DNS server to query (same syntax as the `@server` option)
+* **Args** – additional flags or record types passed verbatim to `dig`
+
+Example of a complex dig test command produced by these fields:
+
+```bash
+dig +short 2.0.0.127.dnsbl.example.com @8.8.8.8 TXT -p 5300 +time=2 +tries=1
+```
+
+
 ## Setup
 
 1. Install dependencies:

--- a/blacklist_monitor/static/style.css
+++ b/blacklist_monitor/static/style.css
@@ -255,4 +255,5 @@ button, input[type="submit"] {
 .small-note {
     font-size: 0.9em;
     color: #555;
+    margin-bottom: 1em;
 }

--- a/blacklist_monitor/templates/backups.html
+++ b/blacklist_monitor/templates/backups.html
@@ -123,6 +123,7 @@
     <input type="submit" value="Save">
 </form>
 <p class="small-note">Keep Days removes backups older than the specified days. Keep Count limits the total number of backups.</p>
+<br>
 <h2>Existing Backups</h2>
 <form method="post">
     <div class="action-buttons">


### PR DESCRIPTION
## Summary
- document DNSBL dig test usage in README
- add margin and a break before the `Existing Backups` heading
- ensure `.small-note` has bottom margin for visual spacing

## Testing
- `python -m py_compile blacklist_monitor/app.py`

------
https://chatgpt.com/codex/tasks/task_e_686e0f70a0388321810f627dd5c465fa