### PR TITLE
Enhance DNSBL dig UI and dropdowns

### DIFF
--- a/blacklist_monitor/static/script.js
+++ b/blacklist_monitor/static/script.js
@@ -232,4 +232,20 @@ window.addEventListener('load', function() {
     });
     updateText();
   });
+
+  // Persist dig test fields across visits
+  document.querySelectorAll('input[name^="dig_ip_"],
+                           input[name^="dig_server_"],
+                           input[name^="dig_arg_"]').forEach(function(inp) {
+    var key = 'cache_' + inp.name;
+    var saved = localStorage.getItem(key);
+    if (!inp.value && saved) {
+      inp.value = saved;
+    } else if (inp.value) {
+      localStorage.setItem(key, inp.value);
+    }
+    inp.addEventListener('input', function() {
+      localStorage.setItem(key, this.value);
+    });
+  });
 });

--- a/blacklist_monitor/static/style.css
+++ b/blacklist_monitor/static/style.css
@@ -1,7 +1,7 @@
 body {
     font-family: Arial, sans-serif;
     margin: 0;
-    font-size: 16px;
+    font-size: 18px;
 }
 
 .container {
@@ -231,11 +231,12 @@ button, input[type="submit"] {
 
 .dropdown-details summary {
     padding: 0.4em;
-    width: 150px;
+    min-width: 150px;
     border: 1px solid #ccc;
     border-radius: 4px;
     cursor: pointer;
     list-style: none;
+    display: inline-block;
 }
 
 .dropdown-details div {
@@ -246,6 +247,7 @@ button, input[type="submit"] {
     max-height: 200px;
     overflow-y: auto;
     z-index: 10;
+    min-width: 150px;
 }
 
 .type-label {

--- a/blacklist_monitor/templates/dnsbls.html
+++ b/blacklist_monitor/templates/dnsbls.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Domain Name System Blacklists</h1>
+<p class="small-note">The Dig Test reverses the IP, appends it to the DNSBL domain and queries the chosen DNS server. Additional arguments are passed directly to <code>dig</code>. Example using IP <code>127.0.0.2</code>, DNS Server <code>1.1.1.1</code> and Arguments <code>+short</code>.</p>
 <form method="post">
     <input type="text" name="dnsbl" placeholder="dnsbl.example.com" required class="telegram-input">
     <input type="submit" value="Add">
@@ -18,17 +19,17 @@
             <th><input type="checkbox" onclick="toggleAll(this)"></th>
             <th>DNSBL</th>
             <th>IP</th>
-            <th>Server</th>
-            <th>Args</th>
+            <th>DNS Server</th>
+            <th>Arguments</th>
             <th>Result</th>
         </tr>
         {% for dnsbl in dnsbls %}
         <tr>
             <td><input type="checkbox" name="dnsbl_id" value="{{ dnsbl[0] }}"></td>
             <td>{{ dnsbl[1] }}</td>
-            <td><input type="text" name="dig_ip_{{ dnsbl[0] }}" class="telegram-input" value="{{ request.form.get('dig_ip_' ~ dnsbl[0], '') }}"></td>
-            <td><input type="text" name="dig_server_{{ dnsbl[0] }}" class="telegram-input" value="{{ request.form.get('dig_server_' ~ dnsbl[0], '') }}"></td>
-            <td><input type="text" name="dig_arg_{{ dnsbl[0] }}" class="telegram-input" value="{{ request.form.get('dig_arg_' ~ dnsbl[0], '') }}"></td>
+            <td><input type="text" name="dig_ip_{{ dnsbl[0] }}" class="telegram-input dig-field" value="{{ request.form.get('dig_ip_' ~ dnsbl[0], '') }}"></td>
+            <td><input type="text" name="dig_server_{{ dnsbl[0] }}" class="telegram-input dig-field" value="{{ request.form.get('dig_server_' ~ dnsbl[0], '') }}"></td>
+            <td><input type="text" name="dig_arg_{{ dnsbl[0] }}" class="telegram-input dig-field" value="{{ request.form.get('dig_arg_' ~ dnsbl[0], '') }}"></td>
             <td>{{ dig_results[dnsbl[0]] if dig_results and dnsbl[0] in dig_results else '' }}</td>
         </tr>
         {% endfor %}


### PR DESCRIPTION
## Summary
- explain how the dig test works on the DNSBL page and rename columns
- persist dig test parameters in localStorage
- bump base font size and allow dropdowns to expand

## Testing
- `python -m py_compile app.py`
- `find blacklist_monitor -name "*.py" -print0 | xargs -0 python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_686e1f79b4388321addfa139b58e72c7