### PR TITLE
UI dropdown improvements

### DIFF
--- a/blacklist_monitor/static/script.js
+++ b/blacklist_monitor/static/script.js
@@ -244,8 +244,19 @@ window.addEventListener('load', function() {
     } else if (inp.value) {
       localStorage.setItem(key, inp.value);
     }
-    inp.addEventListener('input', function() {
-      localStorage.setItem(key, this.value);
+      inp.addEventListener('input', function() {
+        localStorage.setItem(key, this.value);
+      });
+  });
+
+  // Save dig test fields on form submit
+  document.querySelectorAll('form').forEach(function(frm) {
+    frm.addEventListener('submit', function() {
+      document.querySelectorAll('input[name^="dig_ip_"],
+                               input[name^="dig_server_"],
+                               input[name^="dig_arg_"]').forEach(function(inp) {
+        localStorage.setItem('cache_' + inp.name, inp.value);
+      });
     });
   });
 });

--- a/blacklist_monitor/static/style.css
+++ b/blacklist_monitor/static/style.css
@@ -210,7 +210,8 @@ button, input[type="submit"] {
 
 .checkbox-dropdown button {
     padding: 0.4em;
-    width: 150px;
+    width: 300px;
+    text-align: left;
 }
 
 .checkbox-dropdown-menu {

--- a/blacklist_monitor/templates/_schedule_form.html
+++ b/blacklist_monitor/templates/_schedule_form.html
@@ -13,15 +13,15 @@
         {% endfor %}
     </select>
     {% else %}
-    <details class="dropdown-details">
-        <summary>Select Groups</summary>
-        <div>
+    <div class="checkbox-dropdown">
+        <button type="button">Select Groups</button>
+        <div class="checkbox-dropdown-menu">
             <label><input type="checkbox" name="group_ids" value=""> All Groups</label><br>
             {% for g in groups %}
             <label><input type="checkbox" name="group_ids" value="{{ g[0] }}"> {{ g[1] }}</label><br>
             {% endfor %}
         </div>
-    </details>
+    </div>
     {% endif %}
     <input type="hidden" name="type" id="schedule-type" value="{{ edit_schedule.type if edit_schedule else 'daily' }}">
     <label class="type-label"><input type="checkbox" id="schedule-daily" onclick="selectType('schedule','daily')" {% if not edit_schedule or edit_schedule.type=='daily' %}checked{% endif %}>Daily</label>
@@ -71,15 +71,15 @@
         <tr class="schedule-row" data-row-id="{{ s.id }}">
             <td><input type="checkbox" name="schedule_id" value="{{ s.id }}"></td>
             <td>
-                <details class="dropdown-details">
-                    <summary>Select Groups</summary>
-                    <div>
+                <div class="checkbox-dropdown">
+                    <button type="button">Select Groups</button>
+                    <div class="checkbox-dropdown-menu">
                         <label><input type="checkbox" name="group_id_{{ s.id }}" value="" {% if not s.group_id %}checked{% endif %}> All Groups</label><br>
                         {% for g in groups %}
                         <label><input type="checkbox" name="group_id_{{ s.id }}" value="{{ g[0] }}" {% if s.group_id==g[0] %}checked{% endif %}> {{ g[1] }}</label><br>
                         {% endfor %}
                     </div>
-                </details>
+                </div>
             </td>
             <td>
                 <input type="hidden" name="type_{{ s.id }}" id="row-{{ s.id }}-type" value="{{ s.type }}">

--- a/blacklist_monitor/templates/dnsbls.html
+++ b/blacklist_monitor/templates/dnsbls.html
@@ -1,7 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Domain Name System Blacklists</h1>
-<p class="small-note">The Dig Test reverses the IP, appends it to the DNSBL domain and queries the chosen DNS server. Additional arguments are passed directly to <code>dig</code>. Example using IP <code>127.0.0.2</code>, DNS Server <code>1.1.1.1</code> and Arguments <code>+short</code>.</p>
 <form method="post">
     <input type="text" name="dnsbl" placeholder="dnsbl.example.com" required class="telegram-input">
     <input type="submit" value="Add">
@@ -9,11 +8,12 @@
 <h2>Bulk Add</h2>
 <form method="post">
     <textarea name="dnsbls_bulk" rows="4" cols="40" placeholder="one DNSBL per line" class="telegram-input"></textarea>
-    <br>
-    <button type="submit" formaction="{{ url_for('bulk_dnsbls') }}">Add List</button>
-    <button type="submit" formaction="{{ url_for('delete_selected_dnsbls') }}">Delete Selected</button>
-    <button type="submit" formaction="{{ url_for('dig_selected_dnsbls') }}">Dig Test</button>
-    <br><br>
+    <div class="action-buttons">
+        <button type="submit" formaction="{{ url_for('bulk_dnsbls') }}">Add List</button>
+        <button type="submit" formaction="{{ url_for('delete_selected_dnsbls') }}">Delete Selected</button>
+        <button type="submit" formaction="{{ url_for('dig_selected_dnsbls') }}">Dig Test</button>
+    </div>
+    <p class="small-note">The Dig Test reverses the IP, appends it to the DNSBL domain and queries the chosen DNS server. Additional arguments are passed directly to <code>dig</code>. Example using IP <code>127.0.0.2</code>, DNS Server <code>1.1.1.1</code> and Arguments <code>+short</code>.</p>
     <table>
         <tr>
             <th><input type="checkbox" onclick="toggleAll(this)"></th>

--- a/blacklist_monitor/templates/groups.html
+++ b/blacklist_monitor/templates/groups.html
@@ -3,14 +3,14 @@
 <h1>Groups</h1>
 <form method="post" class="action-buttons">
     <input type="text" name="group" placeholder="Group name" required class="telegram-input">
-    <details class="dropdown-details">
-        <summary>Select Chats</summary>
-        <div>
+    <div class="checkbox-dropdown">
+        <button type="button">Select Chats</button>
+        <div class="checkbox-dropdown-menu">
             {% for c in chats %}
             <label><input type="checkbox" name="add_chats" value="{{ c[0] }}"> {{ c[1] }}</label><br>
             {% endfor %}
         </div>
-    </details>
+    </div>
     <input type="submit" value="Add">
 </form>
 
@@ -30,14 +30,14 @@
             <td><input type="checkbox" name="group_id" value="{{ g[0] }}"></td>
             <td><input type="text" name="group_name_{{ g[0] }}" value="{{ g[1] }}" class="telegram-input name-input"></td>
             <td>
-                <details class="dropdown-details">
-                    <summary>Select Chats</summary>
-                    <div>
+                <div class="checkbox-dropdown">
+                    <button type="button">Select Chats</button>
+                    <div class="checkbox-dropdown-menu">
                         {% for c in chats %}
                         <label><input type="checkbox" name="chats_{{ g[0] }}" value="{{ c[0] }}" {% if c[0] in group_chats.get(g[0], []) %}checked{% endif %}> {{ c[1] }}</label><br>
                         {% endfor %}
                     </div>
-                </details>
+                </div>
             </td>
         </tr>
         {% endfor %}


### PR DESCRIPTION
## Summary
- persist dig test values across navigation and submit
- improve DNSBLs layout and spacing
- use wider multi-select dropdowns for groups and schedules

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686e2ea0a0788321ac7efff5c72cabda