### PR TITLE
Update selectors for group and schedule pages

### DIFF
--- a/blacklist_monitor/static/style.css
+++ b/blacklist_monitor/static/style.css
@@ -111,6 +111,12 @@ button, input[type="submit"] {
     margin: 0.2em 0;
     width: 300px;
 }
+
+.multi-select {
+    padding: 0.4em;
+    margin: 0.2em 0;
+    width: 320px;
+}
 .remark-input {
     width: 220px;
     padding: 0.2em;

--- a/blacklist_monitor/templates/_schedule_form.html
+++ b/blacklist_monitor/templates/_schedule_form.html
@@ -13,15 +13,12 @@
         {% endfor %}
     </select>
     {% else %}
-    <div class="checkbox-dropdown">
-        <button type="button">Select Groups</button>
-        <div class="checkbox-dropdown-menu">
-            <label><input type="checkbox" name="group_ids" value=""> All Groups</label><br>
-            {% for g in groups %}
-            <label><input type="checkbox" name="group_ids" value="{{ g[0] }}"> {{ g[1] }}</label><br>
-            {% endfor %}
-        </div>
-    </div>
+    <select name="group_ids" multiple size="5" class="telegram-input multi-select">
+        <option value="">All Groups</option>
+        {% for g in groups %}
+        <option value="{{ g[0] }}">{{ g[1] }}</option>
+        {% endfor %}
+    </select>
     {% endif %}
     <input type="hidden" name="type" id="schedule-type" value="{{ edit_schedule.type if edit_schedule else 'daily' }}">
     <label class="type-label"><input type="checkbox" id="schedule-daily" onclick="selectType('schedule','daily')" {% if not edit_schedule or edit_schedule.type=='daily' %}checked{% endif %}>Daily</label>
@@ -71,15 +68,12 @@
         <tr class="schedule-row" data-row-id="{{ s.id }}">
             <td><input type="checkbox" name="schedule_id" value="{{ s.id }}"></td>
             <td>
-                <div class="checkbox-dropdown">
-                    <button type="button">Select Groups</button>
-                    <div class="checkbox-dropdown-menu">
-                        <label><input type="checkbox" name="group_id_{{ s.id }}" value="" {% if not s.group_id %}checked{% endif %}> All Groups</label><br>
-                        {% for g in groups %}
-                        <label><input type="checkbox" name="group_id_{{ s.id }}" value="{{ g[0] }}" {% if s.group_id==g[0] %}checked{% endif %}> {{ g[1] }}</label><br>
-                        {% endfor %}
-                    </div>
-                </div>
+                <select name="group_id_{{ s.id }}" class="wide-select">
+                    <option value="" {% if not s.group_id %}selected{% endif %}>All Groups</option>
+                    {% for g in groups %}
+                    <option value="{{ g[0] }}" {% if s.group_id==g[0] %}selected{% endif %}>{{ g[1] }}</option>
+                    {% endfor %}
+                </select>
             </td>
             <td>
                 <input type="hidden" name="type_{{ s.id }}" id="row-{{ s.id }}-type" value="{{ s.type }}">

--- a/blacklist_monitor/templates/groups.html
+++ b/blacklist_monitor/templates/groups.html
@@ -3,14 +3,11 @@
 <h1>Groups</h1>
 <form method="post" class="action-buttons">
     <input type="text" name="group" placeholder="Group name" required class="telegram-input">
-    <div class="checkbox-dropdown">
-        <button type="button">Select Chats</button>
-        <div class="checkbox-dropdown-menu">
-            {% for c in chats %}
-            <label><input type="checkbox" name="add_chats" value="{{ c[0] }}"> {{ c[1] }}</label><br>
-            {% endfor %}
-        </div>
-    </div>
+    <select name="add_chats" multiple size="5" class="telegram-input multi-select">
+        {% for c in chats %}
+        <option value="{{ c[0] }}">{{ c[1] }}</option>
+        {% endfor %}
+    </select>
     <input type="submit" value="Add">
 </form>
 
@@ -30,14 +27,11 @@
             <td><input type="checkbox" name="group_id" value="{{ g[0] }}"></td>
             <td><input type="text" name="group_name_{{ g[0] }}" value="{{ g[1] }}" class="telegram-input name-input"></td>
             <td>
-                <div class="checkbox-dropdown">
-                    <button type="button">Select Chats</button>
-                    <div class="checkbox-dropdown-menu">
-                        {% for c in chats %}
-                        <label><input type="checkbox" name="chats_{{ g[0] }}" value="{{ c[0] }}" {% if c[0] in group_chats.get(g[0], []) %}checked{% endif %}> {{ c[1] }}</label><br>
-                        {% endfor %}
-                    </div>
-                </div>
+                <select name="chats_{{ g[0] }}" multiple size="5" class="telegram-input multi-select">
+                    {% for c in chats %}
+                    <option value="{{ c[0] }}" {% if c[0] in group_chats.get(g[0], []) %}selected{% endif %}>{{ c[1] }}</option>
+                    {% endfor %}
+                </select>
             </td>
         </tr>
         {% endfor %}


### PR DESCRIPTION
## Summary
- switch group management selectors to multi-select lists
- use multi-select and regular select inputs in schedule form
- support new select styles in CSS
- existing dig test fields persist via localStorage

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686e32d641148321b7a391b5079a7c99