### PR TITLE
Adjust forms and table layout

### DIFF
--- a/blacklist_monitor/static/style.css
+++ b/blacklist_monitor/static/style.css
@@ -231,7 +231,7 @@ button, input[type="submit"] {
 
 .dropdown-details summary {
     padding: 0.4em;
-    width: 150px;
+    width: 220px;
     border: 1px solid #ccc;
     border-radius: 4px;
     cursor: pointer;
@@ -246,6 +246,7 @@ button, input[type="submit"] {
     max-height: 200px;
     overflow-y: auto;
     z-index: 10;
+    width: 220px;
 }
 
 .type-label {
@@ -255,5 +256,23 @@ button, input[type="submit"] {
 .small-note {
     font-size: 0.9em;
     color: #555;
+    margin-bottom: 2em;
+}
+
+.dnsbl-buttons {
+    margin-top: 1em;
+    margin-bottom: 0.5em;
+}
+
+.dnsbl-note {
     margin-bottom: 1em;
+}
+
+.checkbox-col {
+    width: 40px;
+    text-align: center;
+}
+
+.telegram-add {
+    margin-left: 1em;
 }

--- a/blacklist_monitor/templates/_schedule_form.html
+++ b/blacklist_monitor/templates/_schedule_form.html
@@ -61,7 +61,7 @@
     </div>
     <table class="schedule-table">
         <tr>
-            <th><input type="checkbox" onclick="toggleAll(this)"></th>
+            <th class="checkbox-col"><input type="checkbox" onclick="toggleAll(this)"></th>
             <th>Group</th>
             <th>Type</th>
             <th>Day</th>
@@ -69,7 +69,7 @@
         </tr>
         {% for s in schedules %}
         <tr class="schedule-row" data-row-id="{{ s.id }}">
-            <td><input type="checkbox" name="schedule_id" value="{{ s.id }}"></td>
+            <td class="checkbox-col"><input type="checkbox" name="schedule_id" value="{{ s.id }}"></td>
             <td>
                 <details class="dropdown-details">
                     <summary>Select Groups</summary>

--- a/blacklist_monitor/templates/backups.html
+++ b/blacklist_monitor/templates/backups.html
@@ -61,7 +61,7 @@
     </div>
     <table class="schedule-table">
         <tr>
-            <th><input type="checkbox" onclick="toggleAll(this)"></th>
+            <th class="checkbox-col"><input type="checkbox" onclick="toggleAll(this)"></th>
             <th>Group</th>
             <th>Type</th>
             <th>Day</th>
@@ -69,7 +69,7 @@
         </tr>
         {% for s in schedules %}
         <tr class="schedule-row" data-row-id="{{ s.id }}">
-            <td><input type="checkbox" name="schedule_id" value="{{ s.id }}"></td>
+            <td class="checkbox-col"><input type="checkbox" name="schedule_id" value="{{ s.id }}"></td>
             <td>
                 <select name="group_id_{{ s.id }}" class="short-select">
                     <option value="">All Groups</option>
@@ -131,10 +131,10 @@
         <button type="submit" name="action" value="delete">Delete Selected</button>
     </div>
     <table>
-        <tr><th><input type="checkbox" onclick="toggleAll(this)"></th><th>ID</th><th>Date</th><th>Status</th><th>Error</th></tr>
+        <tr><th class="checkbox-col"><input type="checkbox" onclick="toggleAll(this)"></th><th>ID</th><th>Date</th><th>Status</th><th>Error</th></tr>
         {% for b in backups %}
         <tr>
-            <td><input type="checkbox" name="backup_id" value="{{ b[0] }}"></td>
+            <td class="checkbox-col"><input type="checkbox" name="backup_id" value="{{ b[0] }}"></td>
             <td>{{ b[0] }}</td>
             <td>{{ b[1] }}</td>
             <td>{{ b[2] }}</td>

--- a/blacklist_monitor/templates/dnsbls.html
+++ b/blacklist_monitor/templates/dnsbls.html
@@ -8,14 +8,16 @@
 <h2>Bulk Add</h2>
 <form method="post">
     <textarea name="dnsbls_bulk" rows="4" cols="40" placeholder="one DNSBL per line" class="telegram-input"></textarea>
+    <div class="dnsbl-buttons">
+        <button type="submit" formaction="{{ url_for('bulk_dnsbls') }}">Add List</button>
+        <button type="submit" formaction="{{ url_for('delete_selected_dnsbls') }}">Delete Selected</button>
+        <button type="submit" formaction="{{ url_for('dig_selected_dnsbls') }}">Dig Test</button>
+    </div>
+    <p class="dnsbl-note small-note">Example dig test values: IP: 127.0.0.2, DNS Server: 1.1.1.1, Arguments: +short.</p>
     <br>
-    <button type="submit" formaction="{{ url_for('bulk_dnsbls') }}">Add List</button>
-    <button type="submit" formaction="{{ url_for('delete_selected_dnsbls') }}">Delete Selected</button>
-    <button type="submit" formaction="{{ url_for('dig_selected_dnsbls') }}">Dig Test</button>
-    <br><br>
     <table>
         <tr>
-            <th><input type="checkbox" onclick="toggleAll(this)"></th>
+            <th class="checkbox-col"><input type="checkbox" onclick="toggleAll(this)"></th>
             <th>DNSBL</th>
             <th>IP</th>
             <th>Server</th>
@@ -24,7 +26,7 @@
         </tr>
         {% for dnsbl in dnsbls %}
         <tr>
-            <td><input type="checkbox" name="dnsbl_id" value="{{ dnsbl[0] }}"></td>
+            <td class="checkbox-col"><input type="checkbox" name="dnsbl_id" value="{{ dnsbl[0] }}"></td>
             <td>{{ dnsbl[1] }}</td>
             <td><input type="text" name="dig_ip_{{ dnsbl[0] }}" class="telegram-input" value="{{ request.form.get('dig_ip_' ~ dnsbl[0], '') }}"></td>
             <td><input type="text" name="dig_server_{{ dnsbl[0] }}" class="telegram-input" value="{{ request.form.get('dig_server_' ~ dnsbl[0], '') }}"></td>

--- a/blacklist_monitor/templates/groups.html
+++ b/blacklist_monitor/templates/groups.html
@@ -21,13 +21,13 @@
     </div>
     <table>
         <tr>
-            <th><input type="checkbox" onclick="toggleAll(this)"></th>
+            <th class="checkbox-col"><input type="checkbox" onclick="toggleAll(this)"></th>
             <th>Group</th>
             <th>Chats</th>
         </tr>
         {% for g in groups %}
         <tr>
-            <td><input type="checkbox" name="group_id" value="{{ g[0] }}"></td>
+            <td class="checkbox-col"><input type="checkbox" name="group_id" value="{{ g[0] }}"></td>
             <td><input type="text" name="group_name_{{ g[0] }}" value="{{ g[1] }}" class="telegram-input name-input"></td>
             <td>
                 <details class="dropdown-details">

--- a/blacklist_monitor/templates/index.html
+++ b/blacklist_monitor/templates/index.html
@@ -12,11 +12,11 @@
         <h3 onclick="toggle('g{{ g[0] }}')" class="group-header">{{ g[1] }}{% if group_next.get(g[0]) %} - {{ group_next[g[0]] }}{% endif %}{% if group_chats.get(g[0]) %} - {{ group_chats[g[0]]|join(', ') }}{% endif %}</h3>
         <div id="g{{ g[0] }}" data-collapse>
         <table>
-            <tr><th><input type="checkbox" onclick="toggleAll(this)"></th><th>IP</th><th>Remark</th><th>Last Checked</th><th>Status</th><th>DNSBL</th><th>Check Excluded</th></tr>
+            <tr><th class="checkbox-col"><input type="checkbox" onclick="toggleAll(this)"></th><th>IP</th><th>Remark</th><th>Last Checked</th><th>Status</th><th>DNSBL</th><th>Check Excluded</th></tr>
             {% for ip in ips %}
                 {% if ip[3] == g[0] %}
                 <tr class="{% if ip[4] %}row-excluded{% elif ip[5] == 1 %}row-listed{% elif ip[5] == 0 %}row-clean{% else %}row-unknown{% endif %}">
-                    <td><input type="checkbox" name="ip_id" value="{{ ip[0] }}"></td>
+                    <td class="checkbox-col"><input type="checkbox" name="ip_id" value="{{ ip[0] }}"></td>
                     <td>{{ ip[1] }}</td>
                     <td><input type="text" name="remark_{{ ip[0] }}" value="{{ ip[6] }}" class="remark-input"></td>
                     <td>{{ ip[2] or 'never' }}</td>
@@ -35,10 +35,10 @@
         <h3 onclick="toggle('g0')" class="group-header">Ungrouped{% if group_next.get(None) %} - {{ group_next[None] }}{% endif %}{% if group_chats.get(None) %} - {{ group_chats[None]|join(', ') }}{% endif %}</h3>
         <div id="g0" data-collapse>
         <table>
-            <tr><th><input type="checkbox" onclick="toggleAll(this)"></th><th>IP</th><th>Remark</th><th>Last Checked</th><th>Status</th><th>DNSBL</th><th>Check Excluded</th></tr>
+            <tr><th class="checkbox-col"><input type="checkbox" onclick="toggleAll(this)"></th><th>IP</th><th>Remark</th><th>Last Checked</th><th>Status</th><th>DNSBL</th><th>Check Excluded</th></tr>
             {% for ip in ungroup %}
             <tr class="{% if ip[4] %}row-excluded{% elif ip[5] == 1 %}row-listed{% elif ip[5] == 0 %}row-clean{% else %}row-unknown{% endif %}">
-                <td><input type="checkbox" name="ip_id" value="{{ ip[0] }}"></td>
+                <td class="checkbox-col"><input type="checkbox" name="ip_id" value="{{ ip[0] }}"></td>
                 <td>{{ ip[1] }}</td>
                 <td><input type="text" name="remark_{{ ip[0] }}" value="{{ ip[6] }}" class="remark-input"></td>
                 <td>{{ ip[2] or 'never' }}</td>

--- a/blacklist_monitor/templates/ips.html
+++ b/blacklist_monitor/templates/ips.html
@@ -36,11 +36,11 @@
         <h3 onclick="toggle('grp{{ g[0] }}')" class="group-header">{{ g[1] }}</h3>
         <div id="grp{{ g[0] }}" data-collapse>
         <table>
-            <tr><th><input type="checkbox" onclick="toggleAll(this)"></th><th>IP</th></tr>
+            <tr><th class="checkbox-col"><input type="checkbox" onclick="toggleAll(this)"></th><th>IP</th></tr>
             {% for ip in ips %}
                 {% if ip[2] == g[0] %}
                 <tr>
-                    <td><input type="checkbox" name="ip_id" value="{{ ip[0] }}"></td>
+                    <td class="checkbox-col"><input type="checkbox" name="ip_id" value="{{ ip[0] }}"></td>
                     <td>{{ ip[1] }}</td>
                 </tr>
                 {% endif %}
@@ -54,10 +54,10 @@
         <h3 onclick="toggle('grp0')" class="group-header">Ungrouped</h3>
         <div id="grp0" data-collapse>
         <table>
-            <tr><th><input type="checkbox" onclick="toggleAll(this)"></th><th>IP</th></tr>
+            <tr><th class="checkbox-col"><input type="checkbox" onclick="toggleAll(this)"></th><th>IP</th></tr>
             {% for ip in ungroup %}
             <tr>
-                <td><input type="checkbox" name="ip_id" value="{{ ip[0] }}"></td>
+                <td class="checkbox-col"><input type="checkbox" name="ip_id" value="{{ ip[0] }}"></td>
                 <td>{{ ip[1] }}</td>
             </tr>
             {% endfor %}

--- a/blacklist_monitor/templates/telegram.html
+++ b/blacklist_monitor/templates/telegram.html
@@ -14,8 +14,7 @@
     <input type="text" name="alert_message" value="{{ message }}" class="telegram-input">
     <label>Resend Times:</label>
     <input type="number" name="resend_times" value="{{ resend_times }}" min="0" class="telegram-time-input">
-    <br>
-    <button type="submit">Add</button>
+    <button type="submit" class="telegram-add">Add</button>
 </form>
 <p>Available placeholders: <code>{ip}</code>, <code>{dnsbl}</code>, <code>{remark}</code>, <code>{date}</code>, <code>{time}</code>, <code>{count}</code></p>
 <p class="placeholder-help">Use these tags inside the alert message to insert the IP address, DNSBL name, your remark, the current date and time, or the number of listings.</p>
@@ -33,7 +32,7 @@
     <table>
         <thead>
             <tr>
-                <th><input type="checkbox" onclick="toggleAll(this)"></th>
+                <th class="checkbox-col"><input type="checkbox" onclick="toggleAll(this)"></th>
                 <th>Name</th>
                 <th>Bot Token</th>
                 <th>Chat ID</th>
@@ -45,7 +44,7 @@
         <tbody>
         {% for c in chats %}
             <tr>
-                <td><input type="checkbox" name="chat_id" value="{{ c[0] }}"></td>
+                <td class="checkbox-col"><input type="checkbox" name="chat_id" value="{{ c[0] }}"></td>
                 <td><input type="text" name="chatname_{{ c[0] }}" value="{{ c[3] }}" class="telegram-input name-input"></td>
                 <td><input type="text" name="token_{{ c[0] }}" value="{{ c[1] }}" class="telegram-input token-input"></td>
                 <td><input type="text" name="chatid_{{ c[0] }}" value="{{ c[2] }}" class="telegram-input chatid-input"></td>


### PR DESCRIPTION
## Summary
- tweak dropdown widths for groups
- align Telegram Add button beside resend input
- add spacing and usage notes for DNSBL dig tests
- standardize checkbox column width across tables

## Testing
- `python -m py_compile blacklist_monitor/app.py`

------
https://chatgpt.com/codex/tasks/task_e_686e40654dc08321b1a9719b58434eff