### PR TITLE
Fix spacing in backups view

### DIFF
--- a/blacklist_monitor/templates/backups.html
+++ b/blacklist_monitor/templates/backups.html
@@ -128,7 +128,6 @@
     <input type="submit" value="Save">
 </form>
 <p class="small-note">Keep Days removes backups older than the specified days. Keep Count limits the total number of backups.</p>
-<br>
 <h2>Existing Backups</h2>
 <form method="post">
     <div class="action-buttons">


### PR DESCRIPTION
## Summary
- remove extraneous `<br>` before the "Existing Backups" heading

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f826fdeb883219794afe937c6f295