### PR TITLE
Fix log history toggle behaviour

### DIFF
--- a/blacklist_monitor/static/script.js
+++ b/blacklist_monitor/static/script.js
@@ -190,12 +190,20 @@ window.addEventListener('load', function() {
             skipHistory = false;
             skipLength = 0;
             this.textContent = 'Skip Stored';
+            stopLogs();
+            if (toggle) {
+              toggle.textContent = 'Resume';
+            }
+            fetchLogs();
           } else {
             skipHistory = true;
             skipLength = 0;
             this.textContent = 'Show Stored';
+            if (toggle) {
+              toggle.textContent = 'Stop';
+            }
+            startLogs();
           }
-          fetchLogs();
         });
       }
       startLogs();


### PR DESCRIPTION
## Summary
- stop streaming when viewing stored logs
- restart streaming after skipping stored logs

## Testing
- `python -m py_compile blacklist_monitor/app.py`


------
https://chatgpt.com/codex/tasks/task_e_686f8b68729883218d40710ccb9de08c