### PR TITLE
Fix log streaming independent from history size

### DIFF
--- a/blacklist_monitor/static/script.js
+++ b/blacklist_monitor/static/script.js
@@ -136,15 +136,20 @@ window.addEventListener('load', function() {
     let skipHistory = false;
     let skipLength = 0;
     function fetchLogs() {
-      fetch('/log_feed').then(function(r) { return r.text(); }).then(function(t) {
+      Promise.all([
+        fetch('/log_stream').then(function(r){ return r.text(); }),
+        fetch('/log_feed').then(function(r){ return r.text(); })
+      ]).then(function(res){
+        const streamText = res[0];
+        const historyText = res[1];
         const pre = document.getElementById('log-output');
         const histPre = document.getElementById('log-history');
         if (histPre) {
-          histPre.textContent = t;
+          histPre.textContent = historyText;
           histPre.scrollTop = histPre.scrollHeight;
         }
         if (pre) {
-          let lines = t.split('\n');
+          let lines = streamText.split('\n');
           if (skipHistory) {
             if (skipLength === 0) {
               skipLength = lines.length;


### PR DESCRIPTION
## Summary
- keep an in-memory buffer for live log streaming
- add `/log_stream` endpoint
- fetch log stream and history separately on log page

## Testing
- `python3 -m py_compile blacklist_monitor/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6870773e617c8321a8d9af12c740ff07