### PR TITLE
Adjust dashboard column labels and widths

### DIFF
--- a/blacklist_monitor/static/style.css
+++ b/blacklist_monitor/static/style.css
@@ -291,3 +291,23 @@ button, input[type="submit"] {
 .telegram-add {
     margin-left: 1em;
 }
+
+.ip-col {
+    width: 150px;
+}
+
+.status-col {
+    width: 90px;
+    text-align: center;
+}
+
+.excluded-col {
+    width: 110px;
+    text-align: center;
+}
+
+.active-col,
+.times-col {
+    width: 80px;
+    text-align: center;
+}

--- a/blacklist_monitor/templates/index.html
+++ b/blacklist_monitor/templates/index.html
@@ -12,17 +12,17 @@
         <h3 onclick="toggle('g{{ g[0] }}')" class="group-header">{{ g[1] }}{% if group_next.get(g[0]) %} - {{ group_next[g[0]] }}{% endif %}{% if group_chats.get(g[0]) %} - {{ group_chats[g[0]]|join(', ') }}{% endif %}</h3>
         <div id="g{{ g[0] }}" data-collapse>
         <table class="dashboard-table">
-            <tr><th class="checkbox-col"><input type="checkbox" onclick="toggleAll(this)"></th><th>IP</th><th>Remark</th><th>Last Checked</th><th>Status</th><th class="dnsbl-col">DNSBL</th><th>Check Excluded</th></tr>
+            <tr><th class="checkbox-col"><input type="checkbox" onclick="toggleAll(this)"></th><th class="ip-col">IP Address</th><th>Remark</th><th>Last Checked</th><th class="status-col">Status</th><th class="dnsbl-col">DNSBL</th><th class="excluded-col">Check Excluded</th></tr>
             {% for ip in ips %}
                 {% if ip[3] == g[0] %}
                 <tr class="{% if ip[4] %}row-excluded{% elif ip[5] == 1 %}row-listed{% elif ip[5] == 0 %}row-clean{% else %}row-unknown{% endif %}">
                     <td class="checkbox-col"><input type="checkbox" name="ip_id" value="{{ ip[0] }}"></td>
-                    <td>{{ ip[1] }}</td>
+                    <td class="ip-col">{{ ip[1] }}</td>
                     <td><input type="text" name="remark_{{ ip[0] }}" value="{{ ip[6] }}" class="remark-input"></td>
                     <td>{{ ip[2] or 'never' }}</td>
-                    <td class="{% if ip[5] == 1 %}status-listed{% elif ip[5] == 0 %}status-clean{% endif %}">{% if ip[5] == 1 %}listed{% elif ip[5] == 0 %}clean{% else %}-{% endif %}</td>
+                    <td class="{% if ip[5] == 1 %}status-listed{% elif ip[5] == 0 %}status-clean{% endif %} status-col">{% if ip[5] == 1 %}listed{% elif ip[5] == 0 %}clean{% else %}-{% endif %}</td>
                     <td class="dnsbl-col">{{ dnsbl_map[ip[0]]|join(', ') }}</td>
-                    <td>{{ 'yes' if ip[4] else 'no' }}</td>
+                    <td class="excluded-col">{{ 'yes' if ip[4] else 'no' }}</td>
                 </tr>
                 {% endif %}
             {% endfor %}
@@ -35,16 +35,16 @@
         <h3 onclick="toggle('g0')" class="group-header">Ungrouped{% if group_next.get(None) %} - {{ group_next[None] }}{% endif %}{% if group_chats.get(None) %} - {{ group_chats[None]|join(', ') }}{% endif %}</h3>
         <div id="g0" data-collapse>
         <table class="dashboard-table">
-            <tr><th class="checkbox-col"><input type="checkbox" onclick="toggleAll(this)"></th><th>IP</th><th>Remark</th><th>Last Checked</th><th>Status</th><th class="dnsbl-col">DNSBL</th><th>Check Excluded</th></tr>
+            <tr><th class="checkbox-col"><input type="checkbox" onclick="toggleAll(this)"></th><th class="ip-col">IP Address</th><th>Remark</th><th>Last Checked</th><th class="status-col">Status</th><th class="dnsbl-col">DNSBL</th><th class="excluded-col">Check Excluded</th></tr>
             {% for ip in ungroup %}
             <tr class="{% if ip[4] %}row-excluded{% elif ip[5] == 1 %}row-listed{% elif ip[5] == 0 %}row-clean{% else %}row-unknown{% endif %}">
                 <td class="checkbox-col"><input type="checkbox" name="ip_id" value="{{ ip[0] }}"></td>
-                <td>{{ ip[1] }}</td>
+                <td class="ip-col">{{ ip[1] }}</td>
                 <td><input type="text" name="remark_{{ ip[0] }}" value="{{ ip[6] }}" class="remark-input"></td>
                 <td>{{ ip[2] or 'never' }}</td>
-                <td class="{% if ip[5] == 1 %}status-listed{% elif ip[5] == 0 %}status-clean{% endif %}">{% if ip[5] == 1 %}listed{% elif ip[5] == 0 %}clean{% else %}-{% endif %}</td>
+                <td class="{% if ip[5] == 1 %}status-listed{% elif ip[5] == 0 %}status-clean{% endif %} status-col">{% if ip[5] == 1 %}listed{% elif ip[5] == 0 %}clean{% else %}-{% endif %}</td>
                 <td class="dnsbl-col">{{ dnsbl_map[ip[0]]|join(', ') }}</td>
-                <td>{{ 'yes' if ip[4] else 'no' }}</td>
+                <td class="excluded-col">{{ 'yes' if ip[4] else 'no' }}</td>
             </tr>
             {% endfor %}
         </table>

--- a/blacklist_monitor/templates/ips.html
+++ b/blacklist_monitor/templates/ips.html
@@ -36,12 +36,12 @@
         <h3 onclick="toggle('grp{{ g[0] }}')" class="group-header">{{ g[1] }}</h3>
         <div id="grp{{ g[0] }}" data-collapse>
         <table>
-            <tr><th class="checkbox-col"><input type="checkbox" onclick="toggleAll(this)"></th><th>IP</th></tr>
+            <tr><th class="checkbox-col"><input type="checkbox" onclick="toggleAll(this)"></th><th class="ip-col">IP Address</th></tr>
             {% for ip in ips %}
                 {% if ip[2] == g[0] %}
                 <tr>
                     <td class="checkbox-col"><input type="checkbox" name="ip_id" value="{{ ip[0] }}"></td>
-                    <td>{{ ip[1] }}</td>
+                    <td class="ip-col">{{ ip[1] }}</td>
                 </tr>
                 {% endif %}
             {% endfor %}
@@ -54,11 +54,11 @@
         <h3 onclick="toggle('grp0')" class="group-header">Ungrouped</h3>
         <div id="grp0" data-collapse>
         <table>
-            <tr><th class="checkbox-col"><input type="checkbox" onclick="toggleAll(this)"></th><th>IP</th></tr>
+            <tr><th class="checkbox-col"><input type="checkbox" onclick="toggleAll(this)"></th><th class="ip-col">IP Address</th></tr>
             {% for ip in ungroup %}
             <tr>
                 <td class="checkbox-col"><input type="checkbox" name="ip_id" value="{{ ip[0] }}"></td>
-                <td>{{ ip[1] }}</td>
+                <td class="ip-col">{{ ip[1] }}</td>
             </tr>
             {% endfor %}
         </table>

--- a/blacklist_monitor/templates/telegram.html
+++ b/blacklist_monitor/templates/telegram.html
@@ -36,9 +36,9 @@
                 <th>Name</th>
                 <th>Bot Token</th>
                 <th>Chat ID</th>
-                <th>Active</th>
+                <th class="active-col">Active</th>
                 <th>Alert Message</th>
-                <th>Times</th>
+                <th class="times-col">Times</th>
             </tr>
         </thead>
         <tbody>
@@ -48,9 +48,9 @@
                 <td><input type="text" name="chatname_{{ c[0] }}" value="{{ c[3] }}" class="telegram-input name-input"></td>
                 <td><input type="text" name="token_{{ c[0] }}" value="{{ c[1] }}" class="telegram-input token-input"></td>
                 <td><input type="text" name="chatid_{{ c[0] }}" value="{{ c[2] }}" class="telegram-input chatid-input"></td>
-                <td><input type="checkbox" name="active_{{ c[0] }}" {% if c[4] %}checked{% endif %}></td>
+                <td class="active-col"><input type="checkbox" name="active_{{ c[0] }}" {% if c[4] %}checked{% endif %}></td>
                 <td><input type="text" name="alert_message_{{ c[0] }}" value="{{ c[5] }}" placeholder="{{ message }}" class="telegram-input"></td>
-                <td><input type="number" name="resend_times_{{ c[0] }}" value="{{ c[6] }}" min="0" class="telegram-time-input"></td>
+                <td class="times-col"><input type="number" name="resend_times_{{ c[0] }}" value="{{ c[6] }}" min="0" class="telegram-time-input"></td>
             </tr>
         {% endfor %}
         </tbody>


### PR DESCRIPTION
## Summary
- rename IP column headers to **IP Address**
- narrow IP, Status and Check Excluded columns on dashboard
- make the same change on the IPs list
- match Times column width to Active on Telegram page

## Testing
- `python -m py_compile app.py`
- `flake8 || true`

------
https://chatgpt.com/codex/tasks/task_e_6870a57a361c8321817fbb9801e50420