### PR TITLE
Adjust dashboard column widths

### DIFF
--- a/blacklist_monitor/static/style.css
+++ b/blacklist_monitor/static/style.css
@@ -56,6 +56,8 @@ body {
 .content {
     flex-grow: 1;
     padding: 1em;
+    max-width: 1000px;
+    margin: 0 auto;
 }
 
 table {
@@ -124,7 +126,7 @@ button, input[type="submit"] {
     width: 300px;
 }
 .remark-input {
-    width: 220px;
+    width: 95%;
     padding: 0.2em;
 }
 .row-listed { background-color: #ffe6e6; }
@@ -284,8 +286,21 @@ button, input[type="submit"] {
 }
 
 .checkbox-col {
-    width: 40px;
+    width: 30px;
     text-align: center;
+}
+
+.remark-col {
+    width: 160px;
+}
+
+.last-col {
+    width: 150px;
+    text-align: center;
+}
+
+.ip-table {
+    table-layout: fixed;
 }
 
 .telegram-add {

--- a/blacklist_monitor/templates/index.html
+++ b/blacklist_monitor/templates/index.html
@@ -12,14 +12,14 @@
         <h3 onclick="toggle('g{{ g[0] }}')" class="group-header">{{ g[1] }}{% if group_next.get(g[0]) %} - {{ group_next[g[0]] }}{% endif %}{% if group_chats.get(g[0]) %} - {{ group_chats[g[0]]|join(', ') }}{% endif %}</h3>
         <div id="g{{ g[0] }}" data-collapse>
         <table class="dashboard-table">
-            <tr><th class="checkbox-col"><input type="checkbox" onclick="toggleAll(this)"></th><th class="ip-col">IP Address</th><th>Remark</th><th>Last Checked</th><th class="status-col">Status</th><th class="dnsbl-col">DNSBL</th><th class="excluded-col">Check Excluded</th></tr>
+            <tr><th class="checkbox-col"><input type="checkbox" onclick="toggleAll(this)"></th><th class="ip-col">IP Address</th><th class="remark-col">Remark</th><th class="last-col">Last Checked</th><th class="status-col">Status</th><th class="dnsbl-col">DNSBL</th><th class="excluded-col">Check Excluded</th></tr>
             {% for ip in ips %}
                 {% if ip[3] == g[0] %}
                 <tr class="{% if ip[4] %}row-excluded{% elif ip[5] == 1 %}row-listed{% elif ip[5] == 0 %}row-clean{% else %}row-unknown{% endif %}">
                     <td class="checkbox-col"><input type="checkbox" name="ip_id" value="{{ ip[0] }}"></td>
                     <td class="ip-col">{{ ip[1] }}</td>
-                    <td><input type="text" name="remark_{{ ip[0] }}" value="{{ ip[6] }}" class="remark-input"></td>
-                    <td>{{ ip[2] or 'never' }}</td>
+                    <td class="remark-col"><input type="text" name="remark_{{ ip[0] }}" value="{{ ip[6] }}" class="remark-input"></td>
+                    <td class="last-col">{{ ip[2] or 'never' }}</td>
                     <td class="{% if ip[5] == 1 %}status-listed{% elif ip[5] == 0 %}status-clean{% endif %} status-col">{% if ip[5] == 1 %}listed{% elif ip[5] == 0 %}clean{% else %}-{% endif %}</td>
                     <td class="dnsbl-col">{{ dnsbl_map[ip[0]]|join(', ') }}</td>
                     <td class="excluded-col">{{ 'yes' if ip[4] else 'no' }}</td>
@@ -35,13 +35,13 @@
         <h3 onclick="toggle('g0')" class="group-header">Ungrouped{% if group_next.get(None) %} - {{ group_next[None] }}{% endif %}{% if group_chats.get(None) %} - {{ group_chats[None]|join(', ') }}{% endif %}</h3>
         <div id="g0" data-collapse>
         <table class="dashboard-table">
-            <tr><th class="checkbox-col"><input type="checkbox" onclick="toggleAll(this)"></th><th class="ip-col">IP Address</th><th>Remark</th><th>Last Checked</th><th class="status-col">Status</th><th class="dnsbl-col">DNSBL</th><th class="excluded-col">Check Excluded</th></tr>
+            <tr><th class="checkbox-col"><input type="checkbox" onclick="toggleAll(this)"></th><th class="ip-col">IP Address</th><th class="remark-col">Remark</th><th class="last-col">Last Checked</th><th class="status-col">Status</th><th class="dnsbl-col">DNSBL</th><th class="excluded-col">Check Excluded</th></tr>
             {% for ip in ungroup %}
             <tr class="{% if ip[4] %}row-excluded{% elif ip[5] == 1 %}row-listed{% elif ip[5] == 0 %}row-clean{% else %}row-unknown{% endif %}">
                 <td class="checkbox-col"><input type="checkbox" name="ip_id" value="{{ ip[0] }}"></td>
                 <td class="ip-col">{{ ip[1] }}</td>
-                <td><input type="text" name="remark_{{ ip[0] }}" value="{{ ip[6] }}" class="remark-input"></td>
-                <td>{{ ip[2] or 'never' }}</td>
+                <td class="remark-col"><input type="text" name="remark_{{ ip[0] }}" value="{{ ip[6] }}" class="remark-input"></td>
+                <td class="last-col">{{ ip[2] or 'never' }}</td>
                 <td class="{% if ip[5] == 1 %}status-listed{% elif ip[5] == 0 %}status-clean{% endif %} status-col">{% if ip[5] == 1 %}listed{% elif ip[5] == 0 %}clean{% else %}-{% endif %}</td>
                 <td class="dnsbl-col">{{ dnsbl_map[ip[0]]|join(', ') }}</td>
                 <td class="excluded-col">{{ 'yes' if ip[4] else 'no' }}</td>

--- a/blacklist_monitor/templates/ips.html
+++ b/blacklist_monitor/templates/ips.html
@@ -35,7 +35,7 @@
     {% for g in groups %}
         <h3 onclick="toggle('grp{{ g[0] }}')" class="group-header">{{ g[1] }}</h3>
         <div id="grp{{ g[0] }}" data-collapse>
-        <table>
+        <table class="ip-table">
             <tr><th class="checkbox-col"><input type="checkbox" onclick="toggleAll(this)"></th><th class="ip-col">IP Address</th></tr>
             {% for ip in ips %}
                 {% if ip[2] == g[0] %}
@@ -53,7 +53,7 @@
     {% if ungroup %}
         <h3 onclick="toggle('grp0')" class="group-header">Ungrouped</h3>
         <div id="grp0" data-collapse>
-        <table>
+        <table class="ip-table">
             <tr><th class="checkbox-col"><input type="checkbox" onclick="toggleAll(this)"></th><th class="ip-col">IP Address</th></tr>
             {% for ip in ungroup %}
             <tr>


### PR DESCRIPTION
## Summary
- tweak dashboard layout
- unify checkbox column width
- widen remark input fields
- limit overall content width

## Testing
- `python -m py_compile blacklist_monitor/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6870b539c9948321b2037299f220a79e